### PR TITLE
macOS port: Finder submenu, native SwiftUI UI, VideoToolbox (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# File Converter for Linux
+# File Converter for Linux & macOS
 
-Linux port of [File Converter](https://github.com/Tichau/FileConverter) by Tichau. Right-click files in your file manager, pick a format, convert.
+Linux and macOS port of [File Converter](https://github.com/Tichau/FileConverter) by Tichau. Right-click files in your file manager, pick a format, convert.
 
 ## Support the project :D
 
@@ -8,7 +8,7 @@ If you find this useful, you can [buy me a coffee](https://paypal.me/alextrysh).
 
 ## Quick Start
 
-### Download the release tarball
+### Linux — download the release tarball
 
 1. Grab `fileconverter-vX.Y.Z-linux-x86_64.tar.gz` from the [Releases page](https://github.com/AlexDevFlow/Media-Converter/releases).
 2. Open a terminal in your downloads folder and run:
@@ -21,7 +21,7 @@ cd fileconverter-v*
 
 The installer detects your file manager and sets up the right-click "File Converter" submenu. The bare `fileconverter` binary is also attached to each release for power users who want to manage placement themselves (`chmod +x fileconverter && ./fileconverter`).
 
-### Run from source
+### Linux — run from source
 
 ```bash
 git clone https://github.com/AlexDevFlow/Media-Converter.git
@@ -29,7 +29,53 @@ cd Media-Converter
 ./install.sh
 ```
 
-Requires Python 3.10+ and PyYAML (`python3-yaml` on most distros).
+Requires Python 3.9+ and PyYAML (`python3-yaml` on most distros).
+
+### macOS
+
+```bash
+git clone https://github.com/AlexDevFlow/Media-Converter.git
+cd Media-Converter
+./install.sh
+```
+
+The installer copies the tool into `~/.local/share/fileconverter` with its own
+private venv (no PyInstaller binary, no Gatekeeper trouble), offers to install
+the media tools via [Homebrew](https://brew.sh) if they're missing, and builds
+a **Finder Sync extension** that puts a real submenu in the right-click menu —
+the same UX as the Dolphin/Nemo submenu on Linux:
+
+```
+Right-click video.mkv >
+  File Converter
+  ├── To Mp4
+  ├── To Mp4 (low quality)
+  ├── To Gif
+  ├── To Mp3
+  ├── ...
+  └── Configure presets...
+```
+
+The submenu only lists presets compatible with every selected file (filtering
+happens per-extension in the extension itself). If the Swift toolchain isn't
+available, the installer falls back to one **UTI-filtered Quick Action per
+preset** instead — same conversions, flatter menu.
+
+Conversions show a **native SwiftUI progress window** with per-file progress,
+ETA and cancel — compiled on the spot by the installer, with a tkinter
+fallback. The settings editor is native too: double-click
+**File Converter.app** (in `~/Applications`) or run `fileconverter --settings`.
+Video encodes can use Apple **VideoToolbox** hardware acceleration — enable
+"Auto-detect" under GPU accel in the settings.
+
+Requirements: macOS 13+, the Xcode Command Line Tools
+(`xcode-select --install` — provides Python 3.9+ and the Swift compiler),
+Homebrew for the media tools. If the submenu doesn't appear right away,
+relaunch Finder (`killall Finder`) or check the extension is enabled under
+System Settings → General → Login Items & Extensions. Note for the tkinter
+fallback: Apple's bundled Tk 8.5 draws blank windows on recent macOS —
+`brew install python-tk` gives the fallback a working Tk if you need it.
+To remove everything: `fileconverter --uninstall`.
 
 ## How It Works
 
@@ -88,7 +134,13 @@ The installer checks for these and tells you what to install.
 | **Ghostscript** | PDF processing | Recommended |
 | **LibreOffice** | Office documents (docx, xlsx, pptx) | Optional |
 
-### Install commands by distro
+### Install commands by platform
+
+**macOS (Homebrew):**
+```bash
+brew install ffmpeg imagemagick ghostscript
+brew install --cask libreoffice   # optional, for document presets
+```
 
 **Ubuntu / Debian:**
 ```bash

--- a/fileconverter/__init__.py
+++ b/fileconverter/__init__.py
@@ -1,3 +1,3 @@
-"""File Converter — Linux port of the Windows file conversion utility."""
+"""File Converter — Linux and macOS port of the Windows file conversion utility."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/fileconverter/cli.py
+++ b/fileconverter/cli.py
@@ -1,4 +1,4 @@
-"""CLI entry point — mirrors the original's interface plus --install/--uninstall for Linux."""
+"""CLI entry point — mirrors the original's interface plus --install/--uninstall."""
 
 from __future__ import annotations
 import argparse
@@ -18,7 +18,7 @@ from fileconverter.jobs.factory import create_job
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
         prog="fileconverter",
-        description="File Converter for Linux — convert files from the command line or context menu.",
+        description="File Converter for Linux and macOS — convert files from the command line or context menu.",
     )
     p.add_argument("--version", action="version", version=f"fileconverter {__version__}")
     p.add_argument("--conversion-preset", dest="preset_name",
@@ -80,7 +80,7 @@ def _collect_files(args: argparse.Namespace) -> list[str]:
 
 
 def _run_headless(jobs: list[ConversionJob], max_workers: int) -> None:
-    """Run conversions without GUI (fallback if GTK unavailable)."""
+    """Run conversions without GUI (fallback when no toolkit is available)."""
     def _worker(job: ConversionJob) -> None:
         try:
             job.prepare()
@@ -95,6 +95,7 @@ def _run_headless(jobs: list[ConversionJob], max_workers: int) -> None:
             f.result()
 
     failed = [j for j in jobs if j.state == ConversionState.FAILED]
+    _notify_headless_result(jobs, failed)
     if failed:
         for j in failed:
             print(_("FAILED: {name} — {error}").format(
@@ -104,6 +105,31 @@ def _run_headless(jobs: list[ConversionJob], max_workers: int) -> None:
         for j in jobs:
             print(_("Done: {name} → {path}").format(
                 name=j.input_filename, path=j.output_path))
+
+
+def _notify_headless_result(jobs: list[ConversionJob], failed: list[ConversionJob]) -> None:
+    """Desktop notification when launched without a terminal (e.g. from the
+    file manager with no GUI toolkit) — otherwise the user gets no feedback."""
+    if sys.stdout.isatty():
+        return
+    try:
+        from fileconverter.ui import notify
+        if failed:
+            notify("File Converter",
+                   _("{done}/{total} completed, {failed} failed").format(
+                       done=len(jobs) - len(failed), total=len(jobs),
+                       failed=len(failed)))
+        else:
+            done = len(jobs)
+            if done == 1:
+                notify("File Converter", _("Done: {name} → {path}").format(
+                    name=jobs[0].input_filename,
+                    path=os.path.basename(jobs[0].output_path)))
+            else:
+                notify("File Converter",
+                       _("{done}/{total} completed").format(done=done, total=done))
+    except Exception:
+        pass
 
 
 def _apply_language_from_settings() -> None:
@@ -126,33 +152,34 @@ def main() -> None:
 
     # --install
     if args.install:
-        from fileconverter.integration.install import run_install
+        from fileconverter.integration import run_install
         run_install()
         return
 
     # --uninstall
     if args.uninstall:
-        from fileconverter.integration.install import run_uninstall
+        from fileconverter.integration import run_uninstall
         run_uninstall()
         return
 
     # --settings
     if args.settings:
+        from fileconverter.ui import UINotAvailable, run_settings_auto
         try:
-            from fileconverter.ui.settings_window import run_settings
-            run_settings()
-        except (ImportError, ValueError):
-            print(_("GTK 4 is required for the settings window."), file=sys.stderr)
+            run_settings_auto()
+        except UINotAvailable:
+            print(_("A GUI toolkit (GTK 4 or tkinter) is required for the settings window."),
+                  file=sys.stderr)
             sys.exit(1)
         return
 
     # No arguments at all → first-run check, then show help or run install
     if not args.preset_name and not args.files:
-        from fileconverter.integration.install import is_installed
+        from fileconverter.integration import is_installed
         if not is_installed():
             print(_("File Converter is not set up yet. Running setup..."))
             print()
-            from fileconverter.integration.install import run_install
+            from fileconverter.integration import run_install
             run_install()
             return
         else:
@@ -204,12 +231,12 @@ def main() -> None:
 
     jobs = [create_job(preset, f, hw_accel=hw_accel) for f in files]
 
+    from fileconverter.ui import UINotAvailable, run_with_progress_auto
     try:
-        from fileconverter.ui.progress_window import run_with_progress
-        run_with_progress(jobs, settings)
-    except (ImportError, ValueError):
+        run_with_progress_auto(jobs, settings)
+    except UINotAvailable:
         if args.verbose:
-            print(_("GTK not available, running headless."), file=sys.stderr)
+            print(_("No GUI toolkit available, running headless."), file=sys.stderr)
         _run_headless(jobs, settings.max_simultaneous_conversions)
 
 

--- a/fileconverter/config.py
+++ b/fileconverter/config.py
@@ -19,7 +19,12 @@ _BASE_DIR = Path(getattr(sys, '_MEIPASS', Path(__file__).parent.parent))
 DEFAULT_PRESETS_FILE = _BASE_DIR / "resources" / "default_presets.yaml"
 
 
-HWACCEL_MODES = ["off", "auto", "nvenc", "vaapi"]
+HWACCEL_MODES = ["off", "auto", "nvenc", "vaapi", "videotoolbox"]
+
+# Human-readable labels for HWACCEL_MODES, index-aligned — shared by the GTK
+# and tkinter settings windows so the dropdowns can't drift apart.
+HWACCEL_LABELS = ["Off", "Auto-detect", "NVENC (NVIDIA)", "VAAPI (AMD/Intel)",
+                  "VideoToolbox (Apple)"]
 
 
 CURRENT_VERSION = 2

--- a/fileconverter/integration/__init__.py
+++ b/fileconverter/integration/__init__.py
@@ -1,1 +1,20 @@
-"""File manager integration modules."""
+"""Platform integration — dispatches to the Linux or macOS installer.
+
+Import `install_hint`, `run_install`, `run_uninstall`, `is_installed` from
+here rather than from a platform module, so conversion backends and the CLI
+stay platform-agnostic.
+"""
+
+from __future__ import annotations
+import sys
+
+if sys.platform == "darwin":
+    from fileconverter.integration.macos import (  # noqa: F401
+        install_hint, is_installed, run_install, run_uninstall,
+    )
+else:
+    from fileconverter.integration.install import (  # noqa: F401
+        install_hint, is_installed, run_install, run_uninstall,
+    )
+
+__all__ = ["install_hint", "is_installed", "run_install", "run_uninstall"]

--- a/fileconverter/integration/macos.py
+++ b/fileconverter/integration/macos.py
@@ -1,0 +1,881 @@
+"""macOS installer — Finder Quick Actions (Services), launchers, Homebrew deps.
+
+Mirrors the Linux installer 1:1 in behaviour, with design choices informed by
+the issue tracker of the Linux version:
+
+- One .workflow per preset, scoped to that preset's input types via UTIs
+  (NSSendFileTypes), so Finder only offers presets that make sense for the
+  selected files — the type-aware grouping proposed for KDE in GH #7.
+- Re-installs glob-remove every "File Converter*" workflow first, so renamed
+  or deleted presets never leave stale menu entries behind (GH #7).
+- Source install into a private venv — no PyInstaller onefile binary, which
+  broke on rolling-release libraries (GH #6) and tripped "not authorized to
+  execute" quarantine policies (GH #5).
+- No GTK anywhere: the GUI is tkinter with a headless fallback (GH #5).
+- Launchers export PATH including the Homebrew prefix: Finder services run
+  with a minimal environment that would otherwise hide ffmpeg/magick/gs.
+"""
+
+from __future__ import annotations
+import json
+import os
+import plistlib
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+from fileconverter.integration.install import _print
+
+APP_DIR = Path.home() / ".local" / "share" / "fileconverter"
+PAYLOAD_DIR = APP_DIR / "app"
+VENV_DIR = APP_DIR / "venv"
+BIN_DIR = APP_DIR / "bin"
+UI_BIN = BIN_DIR / "fileconverter-ui"
+MENU_JSON = APP_DIR / "menu.json"
+LOCAL_BIN = Path.home() / ".local" / "bin"
+SERVICES_DIR = Path.home() / "Library" / "Services"
+SETTINGS_APP = Path.home() / "Applications" / "File Converter Settings.app"
+
+# "File Converter.app" hosts the Finder Sync extension (the real right-click
+# submenu, like the Dolphin/Nemo submenu on Linux) and doubles as the
+# double-clickable settings entry.
+HOST_APP = Path.home() / "Applications" / "File Converter.app"
+HOST_BUNDLE_ID = "org.fileconverter.app"
+EXT_BUNDLE_ID = "org.fileconverter.app.finder-sync"
+
+# Every workflow we create starts with this, so install/uninstall/is_installed
+# all agree on one glob and stale actions from earlier versions get cleaned up.
+WORKFLOW_GLOB = "File Converter*.workflow"
+WORKFLOW_PREFIX = "File Converter - "
+PICKER_WORKFLOW_NAME = "File Converter….workflow"
+PICKER_MENU_ITEM = "File Converter…"
+
+_SOFFICE_APP_PATHS = [
+    "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+    str(Path.home() / "Applications" / "LibreOffice.app" / "Contents" / "MacOS" / "soffice"),
+]
+
+# Homebrew's install prefix differs between Apple Silicon and Intel.
+_BREW_PREFIXES = ["/opt/homebrew/bin", "/usr/local/bin"]
+
+
+# ── Dependency checking ──
+
+def _brew() -> str | None:
+    for prefix in _BREW_PREFIXES:
+        p = os.path.join(prefix, "brew")
+        if os.path.exists(p):
+            return p
+    return shutil.which("brew")
+
+
+_BREW_PACKAGES = {
+    "ffmpeg": "ffmpeg",
+    "imagemagick": "imagemagick",
+    "ghostscript": "ghostscript",
+    "libreoffice": "--cask libreoffice",
+}
+
+
+def install_hint(generic: str) -> str:
+    """Return a macOS-appropriate install hint for a missing dependency."""
+    if _brew() is None:
+        return (f"Install Homebrew from https://brew.sh, then run: "
+                f"brew install {_BREW_PACKAGES.get(generic, generic)}")
+    return f"Install it with: brew install {_BREW_PACKAGES.get(generic, generic)}"
+
+
+def _which_media_path(cmds: list[str]) -> str | None:
+    """shutil.which() plus the Homebrew prefixes, since GUI-launched processes
+    (Finder services) don't have Homebrew on PATH."""
+    for cmd in cmds:
+        found = shutil.which(cmd)
+        if found:
+            return found
+        for prefix in _BREW_PREFIXES:
+            p = os.path.join(prefix, cmd)
+            if os.path.exists(p) and os.access(p, os.X_OK):
+                return p
+    return None
+
+
+def find_soffice() -> str | None:
+    found = _which_media_path(["soffice", "libreoffice"])
+    if found:
+        return found
+    for p in _SOFFICE_APP_PATHS:
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def check_dependencies() -> dict[str, bool]:
+    """Check all dependencies, printing an [OK]/[MISSING] line per tool."""
+    results = {}
+    deps = [
+        ("FFmpeg", lambda: _which_media_path(["ffmpeg"]), "ffmpeg"),
+        ("ImageMagick", lambda: _which_media_path(["magick", "convert"]), "imagemagick"),
+        ("Ghostscript", lambda: _which_media_path(["gs"]), "ghostscript"),
+        ("LibreOffice", find_soffice, "libreoffice"),
+    ]
+    for label, finder, generic in deps:
+        found = finder()
+        if found:
+            _print(f"  [OK] {label}", "green")
+            results[label] = True
+        else:
+            _print(f"  [MISSING] {label} — {install_hint(generic)}", "yellow")
+            results[label] = False
+    return results
+
+
+def _missing_required_formulae() -> list[str]:
+    """Required (non-optional) Homebrew formulae that are absent."""
+    missing = []
+    if not _which_media_path(["ffmpeg"]):
+        missing.append("ffmpeg")
+    if not _which_media_path(["magick", "convert"]):
+        missing.append("imagemagick")
+    if not _which_media_path(["gs"]):
+        missing.append("ghostscript")
+    return missing
+
+
+def _offer_brew_install(missing: list[str]) -> None:
+    """Offer to install missing required tools via Homebrew (interactive only)."""
+    brew = _brew()
+    if not brew:
+        _print("\n  Homebrew not found — install it from https://brew.sh, then run:", "yellow")
+        _print(f"  brew install {' '.join(missing)}\n", "cyan")
+        return
+
+    cmd = f"{brew} install {' '.join(missing)}"
+    if not sys.stdin.isatty():
+        _print(f"\n  Install missing dependencies with:\n  {cmd}\n", "cyan")
+        return
+
+    try:
+        answer = input(f"\n  Install missing dependencies now? [{cmd}] [Y/n] ").strip().lower()
+    except EOFError:
+        answer = "n"
+    if answer in ("", "y", "yes", "s", "si", "sì"):
+        result = subprocess.run([brew, "install"] + missing)
+        if result.returncode == 0:
+            _print("  [OK] Dependencies installed", "green")
+        else:
+            _print("  [WARN] Homebrew reported an error — re-run setup afterwards.", "yellow")
+    else:
+        _print(f"  Skipped. Install later with: {cmd}", "yellow")
+
+
+# ── Runtime resolution (which python + package root the launchers embed) ──
+
+def _package_root() -> Path:
+    """Directory that contains the `fileconverter` package."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _runtime() -> tuple[str, str]:
+    """Return (python_executable, pythonpath_root) for the launcher scripts.
+
+    When running from the canonical installed payload we pin the private venv
+    interpreter; a source checkout gets whatever interpreter is running now.
+    """
+    root = _package_root()
+    venv_py = VENV_DIR / "bin" / "python3"
+    if root == PAYLOAD_DIR and venv_py.exists():
+        return str(venv_py), str(PAYLOAD_DIR)
+    return sys.executable or "/usr/bin/python3", str(root)
+
+
+# ── Launcher scripts ──
+
+def _launcher_path_env() -> str:
+    """PATH prefix so services launched by Finder can find the media tools."""
+    parts = _BREW_PREFIXES + [str(LOCAL_BIN)]
+    return ":".join(parts)
+
+
+def _write_launchers() -> None:
+    LOCAL_BIN.mkdir(parents=True, exist_ok=True)
+    python, root = _runtime()
+
+    launcher = LOCAL_BIN / "fileconverter"
+    launcher.write_text(f"""#!/bin/sh
+# File Converter launcher — generated by `fileconverter --install`
+export PATH="{_launcher_path_env()}:$PATH"
+export PYTHONPATH="{root}:$PYTHONPATH"
+exec "{python}" -m fileconverter "$@"
+""")
+    launcher.chmod(0o755)
+    _print(f"  [OK] Launcher: {launcher}", "green")
+
+    picker = LOCAL_BIN / "fileconverter-pick"
+    picker.write_text(f"""#!/bin/sh
+export PATH="{_launcher_path_env()}:$PATH"
+export PYTHONPATH="{root}:$PYTHONPATH"
+exec "{python}" -m fileconverter.ui.picker "$@"
+""")
+    picker.chmod(0o755)
+    _print(f"  [OK] Picker: {picker}", "green")
+
+
+def _save_binary_path() -> None:
+    from fileconverter.config import CONFIG_DIR
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    (CONFIG_DIR / ".binary_path").write_text(str(LOCAL_BIN / "fileconverter"))
+    (CONFIG_DIR / ".project_root").write_text(_runtime()[1])
+
+
+# ── UTI mapping (GH #7: type-aware context menu) ──
+
+# Documents need explicit UTIs; the media classes use the category UTIs that
+# every registered audio/video/image type conforms to.
+_DOC_UTIS = {
+    "pdf": ["com.adobe.pdf"],
+    "doc": ["com.microsoft.word.doc"],
+    "docx": ["org.openxmlformats.wordprocessingml.document"],
+    "xls": ["com.microsoft.excel.xls"],
+    "xlsx": ["org.openxmlformats.spreadsheetml.sheet"],
+    "ppt": ["com.microsoft.powerpoint.ppt"],
+    "pptx": ["org.openxmlformats.presentationml.presentation"],
+    "odt": ["org.oasis-open.opendocument.text"],
+    "ods": ["org.oasis-open.opendocument.spreadsheet"],
+    "odp": ["org.oasis-open.opendocument.presentation"],
+    "rtf": ["public.rtf"],
+    "txt": ["public.plain-text"],
+    "csv": ["public.comma-separated-values-text"],
+    "html": ["public.html"],
+    "epub": ["org.idpf.epub-container"],
+    "pages": ["com.apple.iwork.pages.sffpages", "com.apple.iwork.pages.pages"],
+    "numbers": ["com.apple.iwork.numbers.sffnumbers", "com.apple.iwork.numbers.numbers"],
+    "key": ["com.apple.iwork.keynote.sffkey", "com.apple.iwork.keynote.key"],
+}
+
+
+# ext → UTI as LaunchServices resolves it on THIS machine, filled by
+# _resolve_system_utis(). Formats no installed app claims (e.g. mkv on a
+# stock Mac) resolve to dynamic UTIs (dyn.*) that do NOT conform to
+# public.movie/audio — without listing those explicitly, Finder would hide
+# every preset on exactly those files.
+_system_uti_cache: dict = {}
+
+
+def _resolve_system_utis(extensions: set) -> dict:
+    missing = sorted(e for e in extensions if e not in _system_uti_cache)
+    if missing:
+        try:
+            with tempfile.TemporaryDirectory(prefix="fileconverter-uti-") as td:
+                paths = []
+                for ext in missing:
+                    p = os.path.join(td, f"probe.{ext}")
+                    open(p, "w").close()
+                    paths.append(p)
+                out = subprocess.run(
+                    ["mdls", "-raw", "-name", "kMDItemContentType"] + paths,
+                    capture_output=True, text=True, timeout=60,
+                ).stdout
+                values = out.split("\0")
+                for ext, uti in zip(missing, values):
+                    uti = uti.strip()
+                    if uti and uti != "(null)":
+                        _system_uti_cache[ext] = uti
+        except (subprocess.SubprocessError, OSError):
+            pass
+    return _system_uti_cache
+
+
+def _utis_for_preset(preset, system_utis: dict) -> list[str]:
+    from fileconverter.helpers import (
+        ANIMATED_IMAGE_EXTENSIONS, AUDIO_EXTENSIONS, IMAGE_EXTENSIONS,
+        VIDEO_EXTENSIONS,
+    )
+    exts = {e.lower().lstrip(".") for e in preset.input_types}
+    utis: set = set()
+    # Category umbrellas: cover every registered type that conforms.
+    if exts & VIDEO_EXTENSIONS:
+        utis.add("public.movie")
+    if exts & AUDIO_EXTENSIONS:
+        utis.add("public.audio")
+    if exts & IMAGE_EXTENSIONS:
+        utis.add("public.image")
+    if exts & ANIMATED_IMAGE_EXTENSIONS:
+        utis.add("com.compuserve.gif")
+    for ext in sorted(exts & set(_DOC_UTIS)):
+        utis.update(_DOC_UTIS[ext])
+    # Exact per-extension UTIs: catches the dyn.* ones the umbrellas miss.
+    for ext in exts:
+        uti = system_utis.get(ext)
+        if uti:
+            utis.add(uti)
+    # A preset with no recognisable inputs still gets a menu entry on any file
+    # rather than silently disappearing.
+    return sorted(utis) or ["public.data"]
+
+
+# ── Quick Action (.workflow) generation ──
+
+def _workflow_info_plist(menu_item: str, send_types: list[str]) -> bytes:
+    return plistlib.dumps({
+        "NSServices": [{
+            "NSBackgroundColorName": "background",
+            "NSIconName": "NSActionTemplate",
+            "NSMenuItem": {"default": menu_item},
+            "NSMessage": "runWorkflowAsService",
+            "NSRequiredContext": {},
+            "NSSendFileTypes": send_types,
+        }],
+    })
+
+
+def _workflow_document(command: str) -> bytes:
+    """A one-action 'Run Shell Script' Quick Action, receiving files as $@."""
+    return plistlib.dumps({
+        "AMApplicationBuild": "528",
+        "AMApplicationVersion": "2.10",
+        "AMDocumentVersion": "2",
+        "actions": [{
+            "action": {
+                "AMAccepts": {
+                    "Container": "List", "Optional": True,
+                    "Types": ["com.apple.cocoa.string"],
+                },
+                "AMActionVersion": "2.0.3",
+                "AMApplication": ["Automator"],
+                "AMParameterProperties": {
+                    "COMMAND_STRING": {},
+                    "CheckedForUserDefaultShell": {},
+                    "inputMethod": {},
+                    "shell": {},
+                    "source": {},
+                },
+                "AMProvides": {
+                    "Container": "List",
+                    "Types": ["com.apple.cocoa.string"],
+                },
+                "ActionBundlePath": "/System/Library/Automator/Run Shell Script.action",
+                "ActionName": "Run Shell Script",
+                "ActionParameters": {
+                    "COMMAND_STRING": command,
+                    "CheckedForUserDefaultShell": True,
+                    # 1 = pass input as arguments ($@) rather than stdin
+                    "inputMethod": 1,
+                    "shell": "/bin/zsh",
+                    "source": "",
+                },
+                "BundleIdentifier": "com.apple.RunShellScript",
+                "CFBundleVersion": "2.0.3",
+                "CanShowSelectedItemsWhenRun": False,
+                "CanShowWhenRun": True,
+                "Category": ["AMCategoryUtilities"],
+                "Class Name": "RunShellScriptAction",
+                "InputUUID": str(uuid.uuid4()).upper(),
+                "Keywords": ["Shell", "Script", "Command", "Run", "Unix"],
+                "OutputUUID": str(uuid.uuid4()).upper(),
+                "UUID": str(uuid.uuid4()).upper(),
+                "UnlocalizedApplications": ["Automator"],
+                "arguments": {
+                    "0": {"default value": 0, "name": "inputMethod",
+                          "required": "0", "type": 0, "uuid": "0"},
+                    "1": {"default value": False, "name": "CheckedForUserDefaultShell",
+                          "required": "0", "type": 0, "uuid": "1"},
+                    "2": {"default value": "", "name": "source",
+                          "required": "0", "type": 0, "uuid": "2"},
+                    "3": {"default value": "", "name": "COMMAND_STRING",
+                          "required": "0", "type": 0, "uuid": "3"},
+                    "4": {"default value": "/bin/sh", "name": "shell",
+                          "required": "0", "type": 0, "uuid": "4"},
+                },
+                "isViewVisible": 1,
+                "location": "309.000000:253.000000",
+                "nibPath": ("/System/Library/Automator/Run Shell Script.action"
+                            "/Contents/Resources/Base.lproj/main.nib"),
+            },
+            "isViewVisible": 1,
+        }],
+        "connectors": {},
+        "workflowMetaData": {
+            "applicationBundleIDsByPath": {},
+            "applicationPaths": [],
+            "inputTypeIdentifier": "com.apple.Automator.fileSystemObject",
+            "outputTypeIdentifier": "com.apple.Automator.nothing",
+            "presentationMode": 15,
+            "processesInput": 0,
+            "serviceApplicationBundleID": "com.apple.finder",
+            "serviceApplicationPath": "/System/Library/CoreServices/Finder.app",
+            "serviceInputTypeIdentifier": "com.apple.Automator.fileSystemObject",
+            "serviceOutputTypeIdentifier": "com.apple.Automator.nothing",
+            "serviceProcessesInput": 0,
+            "systemImageName": "NSActionTemplate",
+            "useAutomaticInputType": 0,
+            "workflowTypeIdentifier": "com.apple.Automator.servicesMenu",
+        },
+    })
+
+
+def _write_workflow(bundle_name: str, menu_item: str, send_types: list[str],
+                    command: str) -> None:
+    bundle = SERVICES_DIR / bundle_name
+    contents = bundle / "Contents"
+    contents.mkdir(parents=True, exist_ok=True)
+    (contents / "Info.plist").write_bytes(_workflow_info_plist(menu_item, send_types))
+    (contents / "document.wflow").write_bytes(_workflow_document(command))
+
+
+def _clean_workflows() -> list[str]:
+    """Remove every File Converter workflow (stale presets included, GH #7)."""
+    removed = []
+    if SERVICES_DIR.exists():
+        for wf in SERVICES_DIR.glob(WORKFLOW_GLOB):
+            shutil.rmtree(wf, ignore_errors=True)
+            removed.append(str(wf))
+    return removed
+
+
+def refresh_services(quiet: bool = False) -> int:
+    """(Re)generate the Finder context-menu integration.
+
+    Always writes menu.json (feeding the Finder Sync submenu) and the generic
+    picker Quick Action. The per-preset Quick Actions are only generated when
+    the submenu extension is NOT active — otherwise the menu would list
+    everything twice. Called by --install and after every settings save, so
+    the Finder menu never drifts out of sync with the config.
+    """
+    from fileconverter.config import load_settings
+    settings = load_settings()
+
+    _write_menu_json(settings)
+
+    SERVICES_DIR.mkdir(parents=True, exist_ok=True)
+    _clean_workflows()
+
+    launcher = shlex.quote(str(LOCAL_BIN / "fileconverter"))
+    picker = shlex.quote(str(LOCAL_BIN / "fileconverter-pick"))
+
+    count = 0
+    if not _extension_enabled():
+        all_exts = set()
+        for preset in settings.presets:
+            all_exts.update(e.lower().lstrip(".") for e in preset.input_types)
+        system_utis = _resolve_system_utis(all_exts)
+
+        for preset in settings.presets:
+            # Bundle names come from preset names; strip path separators.
+            safe = preset.name.replace("/", " - ").replace(":", " ")
+            command = (f"nohup {launcher} --conversion-preset "
+                       f"{shlex.quote(preset.name)} \"$@\" >/dev/null 2>&1 &")
+            _write_workflow(
+                f"{WORKFLOW_PREFIX}{safe}.workflow",
+                preset.short_name,
+                _utis_for_preset(preset, system_utis),
+                command,
+            )
+            count += 1
+
+    # Generic entry: opens the preset picker with the full compatible list —
+    # the macOS twin of the fileconverter-pick fallback on Linux.
+    _write_workflow(
+        PICKER_WORKFLOW_NAME,
+        PICKER_MENU_ITEM,
+        ["public.data"],
+        f"nohup {picker} \"$@\" >/dev/null 2>&1 &",
+    )
+    count += 1
+
+    _pbs_flush()
+    if not quiet:
+        if count == 1:
+            _print("  [OK] Finder submenu active — created 1 Quick Action (picker)", "green")
+        else:
+            _print(f"  [OK] Created {count} Finder Quick Actions in {SERVICES_DIR}", "green")
+    return count
+
+
+def _pbs_flush() -> None:
+    """Ask the pasteboard server to rescan ~/Library/Services."""
+    pbs = "/System/Library/CoreServices/pbs"
+    if os.path.exists(pbs):
+        try:
+            subprocess.run([pbs, "-flush"], capture_output=True, timeout=30)
+            subprocess.run([pbs, "-update"], capture_output=True, timeout=30)
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+
+# ── Finder Sync extension (real context-menu submenu, like Linux) ──
+
+def _write_menu_json(settings) -> None:
+    """Preset list + translations for the Finder submenu. The extension
+    re-reads this on every right-click, so edits apply instantly."""
+    from fileconverter.i18n import _ as tr
+    data = {
+        "strings": {
+            "menu_title": "File Converter",
+            "configure": tr("Configure presets..."),
+        },
+        "presets": [{
+            "name": p.name,
+            "short": p.short_name,
+            "extensions": sorted({e.lower().lstrip(".") for e in p.input_types}),
+            "out": p.output_type.upper(),
+        } for p in settings.presets],
+    }
+    APP_DIR.mkdir(parents=True, exist_ok=True)
+    MENU_JSON.write_text(json.dumps(data, ensure_ascii=False, indent=1))
+
+
+def _extension_enabled() -> bool:
+    try:
+        out = subprocess.run(["/usr/bin/pluginkit", "-m", "-i", EXT_BUNDLE_ID],
+                             capture_output=True, text=True, timeout=15).stdout
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return any(line.strip().startswith("+") for line in out.splitlines())
+
+
+def build_finder_extension(quiet: bool = False) -> str:
+    """Build File Converter.app with the embedded Finder Sync extension.
+
+    Returns "enabled" (submenu active), "built" (needs the System Settings
+    toggle), or "unavailable" (no Swift toolchain / build failure — the
+    UTI-scoped Quick Actions remain the context-menu integration).
+    """
+    swiftc = _find_swiftc()
+    src_dir = Path(__file__).resolve().parent.parent / "ui" / "native"
+    host_src = src_dir / "HostApp.swift"
+    ext_src = src_dir / "FinderSyncExt.swift"
+    if not swiftc or not host_src.exists() or not ext_src.exists():
+        if not quiet:
+            _print("  [NOTE] Swift toolchain not available — Finder submenu skipped,", "yellow")
+            _print("         Quick Actions remain the context-menu integration.", "yellow")
+        return "unavailable"
+
+    app = HOST_APP
+    macos_dir = app / "Contents" / "MacOS"
+    ext = app / "Contents" / "PlugIns" / "FileConverterSync.appex"
+    ext_macos = ext / "Contents" / "MacOS"
+    shutil.rmtree(app, ignore_errors=True)
+    macos_dir.mkdir(parents=True, exist_ok=True)
+    ext_macos.mkdir(parents=True, exist_ok=True)
+
+    # CFBundleSupportedPlatforms is not optional: LaunchServices records the
+    # bundle without it, but pkd silently refuses to list the extension.
+    common = {
+        "CFBundleDevelopmentRegion": "en",
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleSupportedPlatforms": ["MacOSX"],
+        "CFBundleShortVersionString": _app_version(),
+        "CFBundleVersion": _app_version(),
+        "LSMinimumSystemVersion": "13.0",
+    }
+    (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps({
+        **common,
+        "CFBundleName": "File Converter",
+        "CFBundleDisplayName": "File Converter",
+        "CFBundleIdentifier": HOST_BUNDLE_ID,
+        "CFBundleExecutable": "FileConverterHost",
+        "CFBundlePackageType": "APPL",
+        "LSUIElement": True,
+        "NSHighResolutionCapable": True,
+        "CFBundleURLTypes": [{
+            "CFBundleURLName": HOST_BUNDLE_ID,
+            "CFBundleURLSchemes": ["fileconverter"],
+        }],
+    }))
+    (ext / "Contents" / "Info.plist").write_bytes(plistlib.dumps({
+        **common,
+        "CFBundleName": "FileConverterSync",
+        "CFBundleDisplayName": "File Converter",
+        "CFBundleIdentifier": EXT_BUNDLE_ID,
+        "CFBundleExecutable": "FileConverterSync",
+        "CFBundlePackageType": "XPC!",
+        "NSExtension": {
+            "NSExtensionPointIdentifier": "com.apple.FinderSync",
+            "NSExtensionPrincipalClass": "FileConverterSync.FinderSync",
+        },
+    }))
+
+    def _run(cmd: list) -> subprocess.CompletedProcess:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+    steps = [
+        [swiftc, "-O", "-parse-as-library", "-module-name", "FileConverterHost",
+         str(host_src), "-o", str(macos_dir / "FileConverterHost")],
+        [swiftc, "-O", "-parse-as-library", "-module-name", "FileConverterSync",
+         str(ext_src), "-o", str(ext_macos / "FileConverterSync"),
+         "-framework", "FinderSync",
+         "-Xlinker", "-e", "-Xlinker", "_NSExtensionMain"],
+    ]
+    for cmd in steps:
+        try:
+            result = _run(cmd)
+        except (subprocess.SubprocessError, OSError) as e:
+            result = None
+            err = str(e)
+        if result is None or result.returncode != 0:
+            if not quiet:
+                tail = (result.stderr.strip().splitlines()[-3:] if result else [err])
+                _print("  [WARN] Finder extension build failed — Quick Actions remain active", "yellow")
+                for line in tail:
+                    _print(f"         {line}", "yellow")
+            shutil.rmtree(app, ignore_errors=True)
+            return "unavailable"
+
+    # Ad-hoc sign inside-out, then register and try to enable. pkd only
+    # accepts sandboxed app extensions, so the appex gets the sandbox
+    # entitlement plus a read-only exception for menu.json.
+    entitlements = plistlib.dumps({
+        "com.apple.security.app-sandbox": True,
+        "com.apple.security.temporary-exception.files.home-relative-path.read-only":
+            ["/.local/share/fileconverter/"],
+    })
+    with tempfile.NamedTemporaryFile("wb", suffix=".plist", delete=False) as f:
+        f.write(entitlements)
+        ent_path = f.name
+    try:
+        _run(["/usr/bin/codesign", "--force", "-s", "-",
+              "--entitlements", ent_path, str(ext)])
+        _run(["/usr/bin/codesign", "--force", "-s", "-", str(app)])
+    finally:
+        os.unlink(ent_path)
+    lsregister = ("/System/Library/Frameworks/CoreServices.framework/Frameworks/"
+                  "LaunchServices.framework/Support/lsregister")
+    if os.path.exists(lsregister):
+        _run([lsregister, "-f", str(app)])
+    _run(["/usr/bin/pluginkit", "-a", str(ext)])
+    _run(["/usr/bin/pluginkit", "-e", "use", "-i", EXT_BUNDLE_ID])
+
+    if _extension_enabled():
+        if not quiet:
+            _print(f"  [OK] Finder submenu extension: {app}", "green")
+        return "enabled"
+    if not quiet:
+        _print(f"  [OK] Built {app}", "green")
+        _print("  [NOTE] Enable it under System Settings → General →", "yellow")
+        _print("         Login Items & Extensions → Finder, then re-run setup.", "yellow")
+    return "built"
+
+
+# ── Native SwiftUI front-end ──
+
+def _find_swiftc() -> str | None:
+    """swiftc via the xcrun-backed /usr/bin shim — calling the binary inside
+    CommandLineTools directly can't locate the SDK/standard library. Only use
+    the shim when a developer directory is active, otherwise macOS pops the
+    'install the Command Line Tools?' dialog instead of compiling."""
+    try:
+        probe = subprocess.run(["/usr/bin/xcode-select", "-p"],
+                               capture_output=True, text=True, timeout=10)
+        if probe.returncode != 0 or not probe.stdout.strip():
+            return None
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if os.path.exists("/usr/bin/swiftc"):
+        return "/usr/bin/swiftc"
+    return shutil.which("swiftc")
+
+
+def compile_native_ui(quiet: bool = False) -> bool:
+    """Build the SwiftUI renderer (progress window / picker / settings).
+
+    Failure is not fatal — the tkinter front-end takes over. Apple's bundled
+    Tk 8.5 draws blank windows on recent macOS, so the native UI is strongly
+    preferred whenever the Command Line Tools are present.
+    """
+    src = Path(__file__).resolve().parent.parent / "ui" / "native" / "FileConverterUI.swift"
+    if not src.exists():
+        if not quiet:
+            _print("  [WARN] Native UI source missing — using tkinter fallback", "yellow")
+        return False
+    swiftc = _find_swiftc()
+    if not swiftc:
+        if not quiet:
+            _print("  [NOTE] swiftc not found (xcode-select --install) — using tkinter UI", "yellow")
+        return False
+
+    BIN_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            [swiftc, "-O", "-parse-as-library", str(src), "-o", str(UI_BIN)],
+            capture_output=True, text=True, timeout=600,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        if not quiet:
+            _print(f"  [WARN] Native UI build failed ({e}) — using tkinter fallback", "yellow")
+        return False
+    if result.returncode != 0:
+        if not quiet:
+            tail = (result.stderr or "").strip().splitlines()[-3:]
+            _print("  [WARN] Native UI build failed — using tkinter fallback", "yellow")
+            for line in tail:
+                _print(f"         {line}", "yellow")
+        return False
+    UI_BIN.chmod(0o755)
+    if not quiet:
+        _print(f"  [OK] Native UI: {UI_BIN}", "green")
+    return True
+
+
+# ── Settings app bundle (macOS twin of the Linux .desktop entry) ──
+
+def _install_settings_app() -> None:
+    macos_dir = SETTINGS_APP / "Contents" / "MacOS"
+    macos_dir.mkdir(parents=True, exist_ok=True)
+
+    (SETTINGS_APP / "Contents" / "Info.plist").write_bytes(plistlib.dumps({
+        "CFBundleName": "File Converter Settings",
+        "CFBundleDisplayName": "File Converter Settings",
+        "CFBundleIdentifier": "org.fileconverter.settings",
+        "CFBundleExecutable": "fileconverter-settings",
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": _app_version(),
+        "LSMinimumSystemVersion": "11.0",
+        "NSHighResolutionCapable": True,
+    }))
+
+    script = macos_dir / "fileconverter-settings"
+    script.write_text(f"""#!/bin/sh
+exec "{LOCAL_BIN / 'fileconverter'}" --settings
+""")
+    script.chmod(0o755)
+    _print(f"  [OK] Settings app: {SETTINGS_APP}", "green")
+
+
+def _app_version() -> str:
+    try:
+        from fileconverter import __version__
+        return __version__
+    except Exception:
+        return "0.0.0"
+
+
+# ── Main flows ──
+
+def is_installed() -> bool:
+    from fileconverter.config import CONFIG_FILE
+    has_config = CONFIG_FILE.exists()
+    has_services = SERVICES_DIR.exists() and any(SERVICES_DIR.glob(WORKFLOW_GLOB))
+    has_bin = (LOCAL_BIN / "fileconverter").exists()
+    return has_config and (has_services or has_bin)
+
+
+def run_install() -> None:
+    _print("\n=== File Converter for macOS — Setup ===\n", "bold")
+
+    _print("Checking dependencies:", "bold")
+    check_dependencies()
+    missing = _missing_required_formulae()
+    if missing:
+        _offer_brew_install(missing)
+    if find_soffice() is None:
+        _print("  [NOTE] LibreOffice is optional — only needed for document presets", "yellow")
+        _print("         (To Pdf, To Docx, ...): brew install --cask libreoffice", "yellow")
+    print()
+
+    _print("Setting up configuration:", "bold")
+    from fileconverter.config import ensure_config, CONFIG_FILE
+    ensure_config()
+    if CONFIG_FILE.exists():
+        _print(f"  [OK] Config: {CONFIG_FILE}", "green")
+    print()
+
+    _print("Setting up command:", "bold")
+    _write_launchers()
+    _save_binary_path()
+    local_bin = str(LOCAL_BIN)
+    if local_bin not in os.environ.get("PATH", ""):
+        _print(f"  [NOTE] Add {local_bin} to your PATH for terminal use:", "yellow")
+        _print(f"    echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.zshrc", "yellow")
+    print()
+
+    _print("Building native UI (SwiftUI):", "bold")
+    compile_native_ui()
+    print()
+
+    _print("Building Finder submenu (File Converter.app):", "bold")
+    ext_state = build_finder_extension()
+    print()
+
+    _print("Setting up Finder context menu:", "bold")
+    refresh_services()
+    print()
+
+    _print("Setting up app entry:", "bold")
+    if ext_state == "unavailable":
+        _install_settings_app()
+    else:
+        # File Converter.app doubles as the settings entry — drop the old
+        # shell-script settings app from earlier versions.
+        if SETTINGS_APP.exists():
+            shutil.rmtree(SETTINGS_APP, ignore_errors=True)
+        _print(f"  [OK] Settings: double-click {HOST_APP.name} (or fileconverter --settings)", "green")
+    print()
+
+    _print("=== Setup complete! ===\n", "bold")
+    if ext_state == "enabled":
+        _print("Right-click files in Finder → File Converter → choose a preset", "green")
+        _print("(relaunch Finder once — killall Finder — if the submenu isn't there yet)", "green")
+    else:
+        _print("Right-click files in Finder → Quick Actions → choose a preset", "green")
+        _print("(also under the Services submenu; first use may need a few seconds", "green")
+        _print(" for Finder to index the new actions)", "green")
+    _print("Or from terminal: fileconverter --conversion-preset 'To Mp4' file.avi\n", "green")
+
+
+def run_uninstall() -> None:
+    _print("\n=== File Converter — Uninstall ===\n", "bold")
+    removed: list[str] = []
+
+    removed += _clean_workflows()
+    _pbs_flush()
+
+    for name in ("fileconverter", "fileconverter-pick"):
+        p = LOCAL_BIN / name
+        if p.exists():
+            p.unlink()
+            removed.append(str(p))
+
+    if SETTINGS_APP.exists():
+        shutil.rmtree(SETTINGS_APP, ignore_errors=True)
+        removed.append(str(SETTINGS_APP))
+
+    if HOST_APP.exists():
+        try:
+            subprocess.run(["/usr/bin/pluginkit", "-e", "ignore", "-i", EXT_BUNDLE_ID],
+                           capture_output=True, timeout=15)
+        except (subprocess.SubprocessError, OSError):
+            pass
+        shutil.rmtree(HOST_APP, ignore_errors=True)
+        removed.append(str(HOST_APP))
+
+    from fileconverter.config import CONFIG_DIR
+    if CONFIG_DIR.exists():
+        shutil.rmtree(CONFIG_DIR, ignore_errors=True)
+        removed.append(str(CONFIG_DIR))
+
+    if APP_DIR.exists():
+        shutil.rmtree(APP_DIR, ignore_errors=True)
+        removed.append(str(APP_DIR))
+
+    if removed:
+        _print("Removed:", "bold")
+        for r in removed:
+            _print(f"  {r}", "green")
+    else:
+        _print("Nothing to remove — File Converter was not installed.", "yellow")
+    _print("\nUninstall complete.\n", "bold")
+
+
+def main() -> None:
+    if "--uninstall" in sys.argv:
+        run_uninstall()
+    else:
+        run_install()
+
+
+if __name__ == "__main__":
+    main()

--- a/fileconverter/jobs/factory.py
+++ b/fileconverter/jobs/factory.py
@@ -46,6 +46,15 @@ def create_job(preset: ConversionPreset, input_path: str, hw_accel: str = "off")
     if out_type == "ico":
         return FFmpegJob(preset, input_path, hw_accel="off")
 
+    # JP2 needs the OpenJPEG delegate, which some ImageMagick builds lack
+    # (e.g. Homebrew's) — and magick then silently writes the wrong format.
+    # ffmpeg's native JPEG-2000 encoder covers those builds. PDF input still
+    # goes to ImageMagick, which rasterises pages and chains to ffmpeg itself.
+    if out_type == "jp2" and ext != "pdf":
+        from fileconverter.jobs.imagemagick import magick_write_formats
+        if "JP2" not in magick_write_formats():
+            return FFmpegJob(preset, input_path, hw_accel="off")
+
     # Raster image outputs → ImageMagick
     if out_type in _IMAGEMAGICK_OUTPUTS:
         return ImageMagickJob(preset, input_path)

--- a/fileconverter/jobs/ffmpeg.py
+++ b/fileconverter/jobs/ffmpeg.py
@@ -6,11 +6,12 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 
 from fileconverter.i18n import _
-from fileconverter.integration.install import install_hint
+from fileconverter.integration import install_hint
 from fileconverter.jobs.base import ConversionJob
 from fileconverter.path_helpers import generate_unique_path
 from fileconverter.presets import ConversionPreset
@@ -76,6 +77,34 @@ _VAAPI_COMPRESSION_MAP = {
 # Cache for hardware acceleration detection (avoids re-probing)
 _hwaccel_cache: dict[str, bool] = {}
 
+# Cache of the encoders the local ffmpeg build actually ships. Builds differ:
+# Fedora's ffmpeg-free lacks H.264/H.265, Homebrew's ffmpeg 8 dropped
+# libvorbis/libtheora — pick from what's really there instead of failing with
+# a cryptic "Error selecting an encoder".
+_encoders_cache: set | None = None
+
+
+def available_encoders() -> set:
+    global _encoders_cache
+    if _encoders_cache is None:
+        names = set()
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            try:
+                out = subprocess.run(
+                    [ffmpeg, "-hide_banner", "-encoders"],
+                    capture_output=True, text=True, timeout=15,
+                ).stdout
+                for line in out.splitlines():
+                    parts = line.split()
+                    # " V....D libx264  libx264 H.264 ..." — skip the legend
+                    if len(parts) >= 2 and parts[0][0] in "VAS" and parts[1] != "=":
+                        names.add(parts[1])
+            except (subprocess.SubprocessError, OSError):
+                pass
+        _encoders_cache = names
+    return _encoders_cache
+
 
 def _find_closest(table: dict, value: int):
     """Find the closest key in a mapping table and return its value."""
@@ -83,6 +112,13 @@ def _find_closest(table: dict, value: int):
         return table[value]
     closest = min(table.keys(), key=lambda k: abs(k - value))
     return table[closest]
+
+
+def jp2_quality_to_qv(quality: int) -> int:
+    """Map image_quality 0-100 (higher = better) to the native jpeg2000
+    encoder's -q:v 2-31 (lower = better). Shared with the ImageMagick PDF
+    path, which chains to this encoder on builds without OpenJPEG."""
+    return max(2, min(31, round(31 - quality * 29 / 100)))
 
 
 def _vaapi_device() -> str:
@@ -113,6 +149,11 @@ def detect_hwaccel(encoder: str) -> bool:
                "-f", "lavfi", "-i", "color=black:s=320x240:d=0.2",
                "-vf", "format=nv12,hwupload",
                "-c:v", "h264_vaapi", "-f", "null", "-"]
+    elif encoder == "videotoolbox":
+        # -q:v (constant quality) needs Apple Silicon; on Intel this probe
+        # fails and we fall back to software, which is the right call there.
+        cmd = [ffmpeg, "-y", "-f", "lavfi", "-i", "color=black:s=320x240:d=0.2",
+               "-c:v", "h264_videotoolbox", "-q:v", "55", "-f", "null", "-"]
     else:
         _hwaccel_cache[encoder] = False
         return False
@@ -131,15 +172,18 @@ def resolve_hwaccel(setting: str) -> str:
     """Resolve the hardware acceleration setting to an actual mode.
 
     Args:
-        setting: "off", "auto", "nvenc", or "vaapi"
+        setting: "off", "auto", "nvenc", "vaapi", or "videotoolbox"
 
     Returns:
-        "off", "nvenc", or "vaapi" — the resolved mode that actually works.
+        "off", "nvenc", "vaapi", or "videotoolbox" — a mode that actually works.
     """
     if setting == "off":
         return "off"
 
     if setting == "auto":
+        if sys.platform == "darwin":
+            # Apple hardware: VideoToolbox or nothing
+            return "videotoolbox" if detect_hwaccel("videotoolbox") else "off"
         # Prefer NVENC (usually faster), fall back to VAAPI
         if detect_hwaccel("nvenc"):
             return "nvenc"
@@ -148,7 +192,7 @@ def resolve_hwaccel(setting: str) -> str:
         return "off"
 
     # Specific encoder requested — verify it works
-    if setting in ("nvenc", "vaapi") and detect_hwaccel(setting):
+    if setting in ("nvenc", "vaapi", "videotoolbox") and detect_hwaccel(setting):
         return setting
 
     return "off"
@@ -207,6 +251,8 @@ class FFmpegJob(ConversionJob):
             self._build_gif(base)
         elif out_type == "ico":
             self._build_ico(base)
+        elif out_type == "jp2":
+            self._build_jp2(base)
         elif out_type == "m4a":
             self._build_m4a(base)
         elif out_type == "mp3":
@@ -234,6 +280,22 @@ class FFmpegJob(ConversionJob):
     def _channel_args(self) -> list[str]:
         ch = self.preset.get_setting_int("audio_channel_count", 0)
         return ["-ac", str(ch)] if ch > 0 else []
+
+    # --- Vorbis audio with build-dependent fallbacks ---
+    def _vorbis_audio(self, bitrate: int, allow_opus: bool = False) -> list[str]:
+        """Encoder args for Vorbis-family audio (ogg/ogv/webm).
+
+        Prefers libvorbis; falls back to libopus where the container allows it
+        (WebM), then to ffmpeg's built-in experimental vorbis encoder (which
+        is stereo-only, hence the -ac 2).
+        """
+        encoders = available_encoders()
+        if "libvorbis" in encoders:
+            q = _find_closest(_OGG_VBR_MAP, bitrate)
+            return ["-c:a", "libvorbis", "-qscale:a", str(q)]
+        if allow_opus and "libopus" in encoders:
+            return ["-c:a", "libopus", "-b:a", f"{bitrate}k"]
+        return ["-c:a", "vorbis", "-strict", "-2", "-ac", "2", "-b:a", f"{bitrate}k"]
 
     # --- Video transform filter args ---
     def _transform_args(self, hw_mode: str = "off", pin_format: str | None = "yuv420p") -> str:
@@ -320,7 +382,40 @@ class FFmpegJob(ConversionJob):
         self._passes.append(_FFmpegPass("Conversion", args2, file_to_delete=palette))
 
     def _build_ico(self, base: list[str]) -> None:
-        args = base + ["-i", self.input_path, self.output_path]
+        # ICO caps at 256x256 — fit larger sources into the box, keeping the
+        # aspect ratio; smaller ones pass through untouched.
+        fit = "scale=min(iw\\,256):min(ih\\,256):force_original_aspect_ratio=decrease"
+        args = base + ["-i", self.input_path, "-vf", fit, self.output_path]
+        self._passes.append(_FFmpegPass(_("Conversion"), args))
+
+    def _build_jp2(self, base: list[str]) -> None:
+        """JPEG-2000 via ffmpeg's native encoder — the fallback used when
+        ImageMagick was built without the OpenJPEG delegate. `-format jp2`
+        wraps the codestream in a proper JP2 container."""
+        quality = self.preset.get_setting_int("image_quality", 85)
+        q = jp2_quality_to_qv(quality)
+
+        # Honour the image transform settings the ImageMagick path applies.
+        parts = []
+        scale = self.preset.get_setting_float("image_scale", 1.0)
+        if abs(scale - 1.0) >= 0.005:
+            sf = f"{scale:#.4g}"
+            parts.append(f"scale=trunc(iw*{sf}):trunc(ih*{sf})")
+        rotation = self.preset.get_setting_float("image_rotation", 0) % 360
+        if abs(rotation - 90) <= 0.05:
+            parts.append("transpose=1")   # clockwise, matching `magick -rotate 90`
+        elif abs(rotation - 180) <= 0.05:
+            parts.append("vflip,hflip")
+        elif abs(rotation - 270) <= 0.05:
+            parts.append("transpose=2")
+        elif abs(rotation) > 0.05:
+            rad = f"{rotation}*PI/180"
+            parts.append(f"rotate={rad}:ow=rotw({rad}):oh=roth({rad})")
+        vf = ["-vf", ",".join(parts)] if parts else []
+
+        args = base + ["-i", self.input_path] + vf + [
+            "-c:v", "jpeg2000", "-format", "jp2", "-q:v", str(q),
+            self.output_path]
         self._passes.append(_FFmpegPass(_("Conversion"), args))
 
     def _build_m4a(self, base: list[str]) -> None:
@@ -472,6 +567,18 @@ class FFmpegJob(ConversionJob):
             else:
                 vf = ["-vf", vaapi_filters]
 
+        elif hw == "videotoolbox":
+            # Apple VideoToolbox — macOS replacement for NVENC/VAAPI.
+            # Frames stay in system memory (no -hwaccel_output_format), so the
+            # regular software scale/rotate/format filters keep working; only
+            # the encode itself runs on the media engine. VT has no speed
+            # presets, and its constant-quality knob is 1-100 (higher =
+            # better) instead of CRF, so map our 0-63 quality onto it.
+            vt_codec = "h264_videotoolbox" if family == "h264" else "hevc_videotoolbox"
+            vt_q = max(1, min(100, round(100 * (vq + 12) / 75)))
+            codec_args = ["-c:v", vt_codec, "-q:v", str(vt_q)]
+            hw_input_args = ["-hwaccel", "videotoolbox"]
+
         else:
             # Software encoding (default, always works)
             codec_args = ["-c:v", sw_codec, "-preset", speed, "-crf", str(crf)]
@@ -520,20 +627,23 @@ class FFmpegJob(ConversionJob):
 
     def _build_ogg(self, base: list[str]) -> None:
         bitrate = self.preset.get_setting_int("audio_bitrate", 128)
-        q = _find_closest(_OGG_VBR_MAP, bitrate)
-        args = base + ["-i", self.input_path, "-vn",
-                        "-codec:a", "libvorbis", "-qscale:a", str(q)]
+        args = base + ["-i", self.input_path, "-vn"] + self._vorbis_audio(bitrate)
         args += self._channel_args() + [self.output_path]
         self._passes.append(_FFmpegPass(_("Conversion"), args))
 
     def _build_ogv(self, base: list[str]) -> None:
+        if "libtheora" not in available_encoders():
+            raise RuntimeError(
+                "This ffmpeg build has no Theora encoder (libtheora), so OGV "
+                "output is unavailable — Homebrew's ffmpeg dropped it. "
+                "Convert to WebM instead."
+            )
         vq = self.preset.get_setting_int("video_quality", 7)
         bitrate = self.preset.get_setting_int("audio_bitrate", 128)
         vf = self._vf_args()
         audio = ["-an"]
         if self.preset.get_setting_bool("enable_audio", True):
-            ogg_q = _find_closest(_OGG_VBR_MAP, bitrate)
-            audio = ["-codec:a", "libvorbis", "-qscale:a", str(ogg_q)]
+            audio = self._vorbis_audio(bitrate)
         args = base + ["-i", self.input_path,
                         "-codec:v", "libtheora", "-qscale:v", str(vq)] + audio + vf
         args += [self.output_path]
@@ -557,8 +667,9 @@ class FFmpegJob(ConversionJob):
         vf = self._vf_args()
         audio = ["-an"]
         if self.preset.get_setting_bool("enable_audio", True):
-            ogg_q = _find_closest(_OGG_VBR_MAP, bitrate)
-            audio = ["-c:a", "libvorbis", "-qscale:a", str(ogg_q)]
+            # WebM allows Vorbis or Opus — _vorbis_audio picks what this
+            # ffmpeg build provides.
+            audio = self._vorbis_audio(bitrate, allow_opus=True)
         args = base + ["-i", self.input_path, "-c:v", "libvpx-vp9"] + enc + audio + vf
         args += [self.output_path]
         self._passes.append(_FFmpegPass(_("Conversion"), args))

--- a/fileconverter/jobs/imagemagick.py
+++ b/fileconverter/jobs/imagemagick.py
@@ -4,13 +4,50 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import tempfile
 
 from fileconverter.i18n import _
-from fileconverter.integration.install import install_hint
+from fileconverter.integration import install_hint
 from fileconverter.jobs.base import ConversionJob
 from fileconverter.presets import ConversionPreset
 
 BASE_DPI_FOR_PDF = 200
+
+# What `identify -format %m` should report per output type. ImageMagick
+# builds missing a write delegate can exit 0 while silently writing the
+# *input* format under the requested extension — validate instead of trusting.
+_EXPECTED_FORMAT = {
+    "avif": "AVIF", "bmp": "BMP", "jp2": "JP2", "jpg": "JPEG", "png": "PNG",
+    "tga": "TGA", "tiff": "TIFF", "webp": "WEBP", "pdf": "PDF",
+}
+
+_write_formats_cache = None
+
+
+def magick_write_formats() -> set:
+    """Formats the local ImageMagick can encode (from `magick -list format`).
+
+    Cached per process. Empty set when ImageMagick is missing entirely.
+    """
+    global _write_formats_cache
+    if _write_formats_cache is None:
+        formats = set()
+        try:
+            cmd = ImageMagickJob._find_convert()
+            args = [cmd, "-list", "format"] if cmd.endswith("magick") \
+                else [cmd.replace("convert", "identify"), "-list", "format"]
+            out = subprocess.run(args, capture_output=True, text=True,
+                                 timeout=30).stdout
+            for line in out.splitlines():
+                #      "     JP2* JP2       rw-   JPEG-2000 ..." — mode has
+                # r=read, w=write; strip the native-blob marker '*'.
+                parts = line.split()
+                if len(parts) >= 3 and "w" in parts[2] and parts[2][0] in "rw-":
+                    formats.add(parts[0].rstrip("*"))
+        except (FileNotFoundError, subprocess.SubprocessError, OSError):
+            pass
+        _write_formats_cache = formats
+    return _write_formats_cache
 
 
 class ImageMagickJob(ConversionJob):
@@ -68,6 +105,12 @@ class ImageMagickJob(ConversionJob):
         scale = self.preset.get_setting_float("image_scale", 1.0)
         dpi = int(BASE_DPI_FOR_PDF * scale) if abs(scale - 1.0) >= 0.005 else BASE_DPI_FOR_PDF
 
+        # Builds without the OpenJPEG delegate can't write JP2 (and would
+        # silently keep another format) — rasterise the page to PNG, then wrap
+        # it with ffmpeg's native JPEG-2000 encoder instead.
+        jp2_via_ffmpeg = (self.preset.output_type == "jp2"
+                          and "JP2" not in magick_write_formats())
+
         num_pages = len(self.output_paths)
         for i, out_path in enumerate(self.output_paths):
             if self.cancel_requested:
@@ -79,21 +122,50 @@ class ImageMagickJob(ConversionJob):
             if self._convert_cmd.endswith("magick"):
                 args.append("convert")
             args += ["-density", str(dpi), f"{self.input_path}[{i}]"]
-            args += self._quality_args()
-            args += [out_path]
 
-            result = subprocess.run(args, capture_output=True, text=True, timeout=300)
-            if result.returncode != 0:
-                raise RuntimeError(f"ImageMagick error: {result.stderr}")
+            if jp2_via_ffmpeg:
+                with tempfile.TemporaryDirectory(prefix="fileconverter-") as tmpdir:
+                    tmp_png = os.path.join(tmpdir, f"page-{i}.png")
+                    result = subprocess.run(args + [tmp_png], capture_output=True,
+                                            text=True, timeout=300)
+                    if result.returncode != 0:
+                        raise RuntimeError(f"ImageMagick error: {result.stderr}")
+                    self._png_to_jp2(tmp_png, out_path)
+            else:
+                args += self._quality_args()
+                args += [out_path]
+                result = subprocess.run(args, capture_output=True, text=True, timeout=300)
+                if result.returncode != 0:
+                    raise RuntimeError(f"ImageMagick error: {result.stderr}")
 
             self.current_output_index = i
+
+    def _png_to_jp2(self, png_path: str, out_path: str) -> None:
+        from fileconverter.jobs.ffmpeg import FFmpegJob, jp2_quality_to_qv
+        ffmpeg = FFmpegJob._find_ffmpeg()
+        quality = self.preset.get_setting_int("image_quality", 85)
+        result = subprocess.run(
+            [ffmpeg, "-y", "-i", png_path, "-c:v", "jpeg2000", "-format", "jp2",
+             "-q:v", str(jp2_quality_to_qv(quality)), out_path],
+            capture_output=True, text=True, timeout=300)
+        if result.returncode != 0:
+            raise RuntimeError(f"ffmpeg error (JP2): {result.stderr[-400:]}")
 
     def _convert_image(self, input_path: str, output_path: str) -> None:
         """Convert a single image file."""
         args = [self._convert_cmd]
         if self._convert_cmd.endswith("magick"):
             args.append("convert")
-        args += [input_path]
+
+        # Animated inputs (gif) to a still format would otherwise explode into
+        # out-0.png, out-1.png, ... and leave the expected output path empty —
+        # take the first frame instead.
+        in_ext = os.path.splitext(input_path)[1].lower().lstrip(".")
+        out_ext = os.path.splitext(output_path)[1].lower().lstrip(".")
+        if in_ext == "gif" and out_ext not in ("gif", "webp", "avif"):
+            args += [f"{input_path}[0]"]
+        else:
+            args += [input_path]
 
         # Scale
         scale = self.preset.get_setting_float("image_scale", 1.0)
@@ -113,6 +185,32 @@ class ImageMagickJob(ConversionJob):
         result = subprocess.run(args, capture_output=True, text=True, timeout=300)
         if result.returncode != 0:
             raise RuntimeError(f"ImageMagick error: {result.stderr}")
+        self._validate_output_format(output_path)
+
+    def _validate_output_format(self, output_path: str) -> None:
+        """Reject outputs whose actual format doesn't match the extension —
+        a build without the needed write delegate exits 0 but keeps the input
+        format (e.g. PNG bytes in a .jp2 file)."""
+        expected = _EXPECTED_FORMAT.get(self.preset.output_type)
+        if not expected:
+            return
+        try:
+            args = [self._convert_cmd]
+            if self._convert_cmd.endswith("magick"):
+                args.append("identify")
+            else:
+                args = [self._convert_cmd.replace("convert", "identify")]
+            out = subprocess.run(args + ["-format", "%m\n", output_path],
+                                 capture_output=True, text=True, timeout=60)
+            actual = out.stdout.strip().splitlines()[0] if out.stdout.strip() else ""
+        except (subprocess.SubprocessError, OSError, IndexError):
+            return  # can't verify — don't fail a conversion that may be fine
+        if actual and actual != expected:
+            raise RuntimeError(
+                f"ImageMagick wrote {actual} data instead of {expected} — this "
+                f"build lacks the {expected} write delegate. "
+                f"{install_hint('imagemagick')}"
+            )
 
     def _quality_args(self) -> list[str]:
         out = self.preset.output_type

--- a/fileconverter/jobs/libreoffice.py
+++ b/fileconverter/jobs/libreoffice.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import zipfile
 
 from fileconverter.helpers import LIBREOFFICE_OUTPUTS
 from fileconverter.i18n import _
-from fileconverter.integration.install import install_hint
+from fileconverter.integration import install_hint
 from fileconverter.jobs.base import ConversionJob
 from fileconverter.jobs.imagemagick import ImageMagickJob
 from fileconverter.presets import ConversionPreset
@@ -37,6 +38,14 @@ class LibreOfficeJob(ConversionJob):
             path = shutil.which(cmd)
             if path:
                 return path
+        if sys.platform == "darwin":
+            # LibreOffice.app isn't on PATH; look inside the app bundle.
+            for p in (
+                "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+                os.path.expanduser("~/Applications/LibreOffice.app/Contents/MacOS/soffice"),
+            ):
+                if os.path.exists(p) and os.access(p, os.X_OK):
+                    return p
         raise FileNotFoundError(
             f"LibreOffice not found. {install_hint('libreoffice')}"
         )

--- a/fileconverter/path_helpers.py
+++ b/fileconverter/path_helpers.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 import os
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 
 _DATE_RE = re.compile(r"\(d:(?P<format>[^)]+)\)")
+
+# macOS calls the videos folder "Movies"; everywhere else it's "Videos".
+_VIDEOS_DIR = Path.home() / ("Movies" if sys.platform == "darwin" else "Videos")
 
 
 def generate_output_path(
@@ -45,8 +49,8 @@ def generate_output_path(
     out = out.replace("(p:documents)", str(Path.home() / "Documents") + os.sep)
     out = out.replace("(p:m)", str(Path.home() / "Music") + os.sep)
     out = out.replace("(p:music)", str(Path.home() / "Music") + os.sep)
-    out = out.replace("(p:v)", str(Path.home() / "Videos") + os.sep)
-    out = out.replace("(p:videos)", str(Path.home() / "Videos") + os.sep)
+    out = out.replace("(p:v)", str(_VIDEOS_DIR) + os.sep)
+    out = out.replace("(p:videos)", str(_VIDEOS_DIR) + os.sep)
     out = out.replace("(p:p)", str(Path.home() / "Pictures") + os.sep)
     out = out.replace("(p:pictures)", str(Path.home() / "Pictures") + os.sep)
 

--- a/fileconverter/ui/__init__.py
+++ b/fileconverter/ui/__init__.py
@@ -1,1 +1,115 @@
-"""UI components using GTK 4."""
+"""UI components — GTK 4 on Linux; native SwiftUI (with a tkinter fallback)
+on macOS.
+
+`run_with_progress_auto` / `run_settings_auto` try the platform's preferred
+front-ends in order and raise `UINotAvailable` when no GUI can be shown, so
+the CLI can fall back to headless mode (GH #5: a missing toolkit must never
+crash a conversion).
+"""
+
+from __future__ import annotations
+import subprocess
+import sys
+
+
+class UINotAvailable(RuntimeError):
+    """No usable GUI toolkit (or no display) — callers should go headless."""
+
+
+def _try_native(fn_name: str, *args):
+    if sys.platform != "darwin":
+        raise UINotAvailable("native UI is macOS-only")
+    try:
+        from fileconverter.ui import native_ui
+    except ImportError as e:
+        raise UINotAvailable(f"native UI not importable: {e}")
+    if not native_ui.available():
+        raise UINotAvailable("fileconverter-ui binary not built")
+    try:
+        if fn_name == "progress":
+            native_ui.run_with_progress(*args)
+        else:
+            native_ui.run_settings(*args)
+    except native_ui.NativeUIUnavailable as e:
+        raise UINotAvailable(str(e))
+
+
+def _try_tk(fn_name: str, *args):
+    try:
+        from fileconverter.ui import progress_window_tk, settings_window_tk
+        module = {"progress": progress_window_tk, "settings": settings_window_tk}[fn_name]
+    except ImportError as e:
+        raise UINotAvailable(f"tkinter not available: {e}")
+    try:
+        if fn_name == "progress":
+            module.run_with_progress(*args)
+        else:
+            module.run_settings(*args)
+    except Exception as e:
+        # tkinter raises TclError when there's no window server session
+        # (ssh, cron); anything raised while *creating* the root window
+        # means "no GUI", not "conversion failed".
+        if type(e).__name__ == "TclError":
+            raise UINotAvailable(f"no display: {e}")
+        raise
+
+
+def _try_gtk(fn_name: str, *args):
+    try:
+        if fn_name == "progress":
+            from fileconverter.ui.progress_window import run_with_progress
+            run_with_progress(*args)
+        else:
+            from fileconverter.ui.settings_window import run_settings
+            run_settings(*args)
+    except (ImportError, ValueError) as e:
+        raise UINotAvailable(f"GTK not available: {e}")
+
+
+def run_with_progress_auto(jobs, settings) -> None:
+    """Show the progress window with whichever front-end this platform has."""
+    order = ["native", "tk"] if sys.platform == "darwin" else ["gtk", "tk"]
+    last = None
+    for toolkit in order:
+        try:
+            if toolkit == "native":
+                return _try_native("progress", jobs, settings)
+            if toolkit == "gtk":
+                return _try_gtk("progress", jobs, settings)
+            return _try_tk("progress", jobs, settings)
+        except UINotAvailable as e:
+            last = e
+    raise last or UINotAvailable("no GUI toolkit available")
+
+
+def run_settings_auto() -> None:
+    order = ["native", "tk"] if sys.platform == "darwin" else ["gtk", "tk"]
+    last = None
+    for toolkit in order:
+        try:
+            if toolkit == "native":
+                return _try_native("settings")
+            if toolkit == "gtk":
+                return _try_gtk("settings")
+            return _try_tk("settings")
+        except UINotAvailable as e:
+            last = e
+    raise last or UINotAvailable("no GUI toolkit available")
+
+
+def notify(title: str, message: str) -> None:
+    """Best-effort desktop notification (used by headless Finder launches)."""
+    try:
+        if sys.platform == "darwin":
+            def esc(s: str) -> str:
+                return s.replace("\\", "\\\\").replace('"', '\\"')
+            subprocess.run(
+                ["osascript", "-e",
+                 f'display notification "{esc(message)}" with title "{esc(title)}"'],
+                capture_output=True, timeout=10,
+            )
+        else:
+            subprocess.run(["notify-send", title, message],
+                           capture_output=True, timeout=10)
+    except (subprocess.SubprocessError, OSError, FileNotFoundError):
+        pass

--- a/fileconverter/ui/native/FileConverterUI.swift
+++ b/fileconverter/ui/native/FileConverterUI.swift
@@ -1,0 +1,712 @@
+// FileConverterUI — native SwiftUI front-end for File Converter on macOS.
+//
+// Compiled at install time by `fileconverter --install` (swiftc from the
+// Xcode Command Line Tools). This binary is a *dumb renderer*: every piece
+// of logic — conversions, ETA math, auto-close timing, i18n — lives in the
+// Python process, which drives this UI over a JSON-lines protocol:
+//
+//   python → stdin : {"type":"init"|"update"|"summary"|"saved"|"exit", ...}
+//   stdout → python: {"ready":true} | {"cancel":N} | {"keep_open":true}
+//                    | {"preset":"To Mp4"} | {"action":"save",...}
+//                    | {"closed":true}
+//
+// Modes (argv[1]): progress | pick | settings
+
+import AppKit
+import Foundation
+import SwiftUI
+
+// MARK: - IO
+
+enum IO {
+    private static let lock = NSLock()
+
+    static func send(_ obj: [String: Any]) {
+        guard JSONSerialization.isValidJSONObject(obj),
+              var data = try? JSONSerialization.data(withJSONObject: obj) else { return }
+        data.append(0x0a)
+        lock.lock()
+        defer { lock.unlock() }
+        // Raw write(2): with SIGPIPE ignored this fails silently if Python
+        // is gone, instead of raising an uncatchable NSException.
+        data.withUnsafeBytes { buf in
+            var off = 0
+            while off < buf.count {
+                let n = write(1, buf.baseAddress!.advanced(by: off), buf.count - off)
+                if n <= 0 { break }
+                off += n
+            }
+        }
+    }
+
+    static func readLoop(_ handler: @escaping ([String: Any]) -> Void) {
+        Thread.detachNewThread {
+            while let line = readLine(strippingNewline: true) {
+                guard !line.isEmpty,
+                      let data = line.data(using: .utf8),
+                      let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+                else { continue }
+                DispatchQueue.main.async { handler(obj) }
+            }
+            // stdin EOF — the Python side is gone; quit quietly.
+            DispatchQueue.main.async {
+                WindowRunner.shared.suppressCloseMessage = true
+                NSApp.terminate(nil)
+            }
+        }
+    }
+}
+
+// MARK: - Window bootstrap
+
+final class WindowRunner: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    static let shared = WindowRunner()
+    var window: NSWindow?
+    var suppressCloseMessage = false
+
+    func run<V: View>(title: String, width: CGFloat, height: CGFloat,
+                      minW: CGFloat, minH: CGFloat, view: V) {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        app.delegate = self
+
+        let win = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: width, height: height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered, defer: false)
+        win.title = title
+        win.minSize = NSSize(width: minW, height: minH)
+        win.isReleasedWhenClosed = false
+        win.contentView = NSHostingView(rootView: view)
+        win.center()
+        win.delegate = self
+        win.makeKeyAndOrderFront(nil)
+        window = win
+
+        app.activate(ignoringOtherApps: true)
+        app.run()
+    }
+
+    func setTitle(_ title: String) { window?.title = title }
+
+    func windowWillClose(_ notification: Notification) {
+        if !suppressCloseMessage {
+            suppressCloseMessage = true
+            IO.send(["closed": true])
+        }
+        NSApp.terminate(nil)
+    }
+}
+
+func str(_ table: [String: String], _ key: String, _ fallback: String) -> String {
+    table[key] ?? fallback
+}
+
+// MARK: - Progress mode
+
+final class JobVM: ObservableObject, Identifiable {
+    let id: Int
+    let name: String
+    let out: String
+    @Published var progress: Double = 0
+    @Published var progressText = ""
+    @Published var status = ""
+    @Published var state = "ready"
+    @Published var cancelling = false
+
+    init(id: Int, name: String, out: String) {
+        self.id = id
+        self.name = name
+        self.out = out
+    }
+}
+
+final class ProgressVM: ObservableObject {
+    @Published var jobs: [JobVM] = []
+    @Published var summary = ""
+    @Published var showKeepOpen = false
+    @Published var strings: [String: String] = [:]
+
+    func handle(_ msg: [String: Any]) {
+        switch msg["type"] as? String {
+        case "init":
+            strings = msg["strings"] as? [String: String] ?? [:]
+            if let title = msg["title"] as? String { WindowRunner.shared.setTitle(title) }
+            jobs = (msg["jobs"] as? [[String: Any]] ?? []).map { j in
+                let vm = JobVM(id: j["id"] as? Int ?? 0,
+                               name: j["name"] as? String ?? "?",
+                               out: j["out"] as? String ?? "")
+                vm.status = str(strings, "waiting", "Waiting...")
+                return vm
+            }
+            IO.send(["ready": true])
+        case "update":
+            guard let id = msg["id"] as? Int,
+                  let job = jobs.first(where: { $0.id == id }) else { return }
+            if let v = msg["progress"] as? Double { job.progress = v }
+            if let v = msg["state"] as? String { job.state = v }
+            if let v = msg["progress_text"] as? String { job.progressText = v }
+            if let v = msg["status"] as? String { job.status = v }
+        case "summary":
+            summary = msg["text"] as? String ?? ""
+            showKeepOpen = msg["show_keep_open"] as? Bool ?? false
+        case "exit":
+            WindowRunner.shared.suppressCloseMessage = true
+            NSApp.terminate(nil)
+        default:
+            break
+        }
+    }
+}
+
+struct JobRowView: View {
+    @ObservedObject var job: JobVM
+    let strings: [String: String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(job.name)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                Text("→ \(job.out)").foregroundColor(.secondary)
+                if job.state == "ready" || job.state == "in_progress" || job.state == "unknown" {
+                    Button(job.cancelling ? str(strings, "cancelling", "Cancelling...")
+                                          : str(strings, "cancel", "Cancel")) {
+                        job.cancelling = true
+                        IO.send(["cancel": job.id])
+                    }
+                    .disabled(job.cancelling)
+                }
+            }
+            HStack(spacing: 8) {
+                ProgressView(value: min(max(job.progress, 0), 1))
+                    .progressViewStyle(.linear)
+                Text(job.progressText)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(minWidth: 140, alignment: .trailing)
+            }
+            Text(job.status)
+                .font(.caption)
+                .foregroundColor(job.state == "failed" ? .red : .secondary)
+                .lineLimit(2)
+            Divider()
+        }
+    }
+}
+
+struct ProgressWindowView: View {
+    @ObservedObject var model: ProgressVM
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(model.jobs) { job in
+                        JobRowView(job: job, strings: model.strings)
+                    }
+                }
+                .padding(12)
+            }
+            Divider()
+            HStack {
+                Text(model.summary).font(.callout)
+                Spacer()
+                if model.showKeepOpen {
+                    Button(str(model.strings, "keep_open", "Keep open")) {
+                        IO.send(["keep_open": true])
+                    }
+                }
+            }
+            .padding(10)
+        }
+        .frame(minWidth: 480, minHeight: 240)
+    }
+}
+
+// MARK: - Pick mode
+
+struct PickPreset: Identifiable {
+    let id: String
+    let short: String
+    let folder: String
+    let out: String
+}
+
+final class PickVM: ObservableObject {
+    @Published var presets: [PickPreset] = []
+    @Published var info = ""
+    @Published var strings: [String: String] = [:]
+
+    func handle(_ msg: [String: Any]) {
+        switch msg["type"] as? String {
+        case "init":
+            strings = msg["strings"] as? [String: String] ?? [:]
+            if let title = msg["title"] as? String { WindowRunner.shared.setTitle(title) }
+            info = msg["info"] as? String ?? ""
+            presets = (msg["presets"] as? [[String: Any]] ?? []).map { p in
+                PickPreset(id: p["name"] as? String ?? "?",
+                           short: p["short"] as? String ?? (p["name"] as? String ?? "?"),
+                           folder: p["folder"] as? String ?? "",
+                           out: p["out"] as? String ?? "")
+            }
+            IO.send(["ready": true])
+        case "exit":
+            WindowRunner.shared.suppressCloseMessage = true
+            NSApp.terminate(nil)
+        default:
+            break
+        }
+    }
+}
+
+struct PickWindowView: View {
+    @ObservedObject var model: PickVM
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(model.info)
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            Divider()
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(model.presets.enumerated()), id: \.element.id) { index, preset in
+                        if !preset.folder.isEmpty,
+                           index == 0 || model.presets[index - 1].folder != preset.folder {
+                            Text(preset.folder)
+                                .font(.headline)
+                                .padding(.top, 8)
+                        }
+                        HStack {
+                            Text(preset.short)
+                            Spacer()
+                            Text(preset.out).foregroundColor(.secondary)
+                            Button(str(model.strings, "convert", "Convert")) {
+                                WindowRunner.shared.suppressCloseMessage = true
+                                IO.send(["preset": preset.id])
+                                NSApp.terminate(nil)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+                .padding(12)
+            }
+        }
+        .frame(minWidth: 380, minHeight: 300)
+    }
+}
+
+// MARK: - Settings mode
+
+struct SettingRowSpec: Identifiable {
+    let id: String
+    let key: String
+    let label: String
+    let kind: String       // "choice" | "int" | "float" | "bool"
+    let options: [String]
+    let minV: Double
+    let maxV: Double
+    let step: Double
+    let defNum: Double
+    let defBool: Bool
+
+    init(_ d: [String: Any]) {
+        key = d["key"] as? String ?? ""
+        id = key
+        label = d["label"] as? String ?? key
+        kind = d["kind"] as? String ?? "int"
+        options = (d["options"] as? [Any] ?? []).compactMap { $0 as? String }
+        minV = (d["min"] as? NSNumber)?.doubleValue ?? 0
+        maxV = (d["max"] as? NSNumber)?.doubleValue ?? 100
+        step = (d["step"] as? NSNumber)?.doubleValue ?? 1
+        defNum = (d["default"] as? NSNumber)?.doubleValue ?? 0
+        defBool = (d["default"] as? NSNumber)?.boolValue ?? true
+    }
+}
+
+final class PresetVM: ObservableObject, Identifiable {
+    let id = UUID()
+    @Published var name: String
+    @Published var outputType: String
+    @Published var inputTypes: Set<String>
+    @Published var postAction: String
+    @Published var template: String
+    var settings: [String: Any]
+
+    init(_ d: [String: Any]) {
+        name = d["name"] as? String ?? "Preset"
+        outputType = d["output_type"] as? String ?? "mp4"
+        inputTypes = Set((d["input_types"] as? [Any] ?? []).compactMap { $0 as? String })
+        postAction = d["input_post_action"] as? String ?? "none"
+        template = d["output_template"] as? String ?? "(p)(f)"
+        settings = d["settings"] as? [String: Any] ?? [:]
+    }
+
+    func toDict() -> [String: Any] {
+        ["name": name,
+         "output_type": outputType,
+         "input_types": inputTypes.sorted(),
+         "input_post_action": postAction,
+         "output_template": template,
+         "settings": settings]
+    }
+
+    func numBinding(_ row: SettingRowSpec, onChange: @escaping () -> Void) -> Binding<Double> {
+        Binding(
+            get: { (self.settings[row.key] as? NSNumber)?.doubleValue ?? row.defNum },
+            set: { v in
+                self.objectWillChange.send()
+                self.settings[row.key] = row.kind == "int" ? Int(v.rounded()) as Any : (v * 100).rounded() / 100
+                onChange()
+            })
+    }
+
+    func boolBinding(_ row: SettingRowSpec, onChange: @escaping () -> Void) -> Binding<Bool> {
+        Binding(
+            get: { (self.settings[row.key] as? NSNumber)?.boolValue ?? row.defBool },
+            set: { v in
+                self.objectWillChange.send()
+                self.settings[row.key] = v
+                onChange()
+            })
+    }
+
+    func choiceBinding(_ row: SettingRowSpec, onChange: @escaping () -> Void) -> Binding<String> {
+        Binding(
+            get: {
+                var v = (self.settings[row.key] as? String ?? row.options.first ?? "").lowercased()
+                if v == "h265" { v = "hevc" }
+                return row.options.contains(v) ? v : (row.options.first ?? "")
+            },
+            set: { v in
+                self.objectWillChange.send()
+                self.settings[row.key] = v
+                onChange()
+            })
+    }
+}
+
+final class SettingsVM: ObservableObject {
+    @Published var presets: [PresetVM] = []
+    @Published var selection: UUID?
+    @Published var maxJobs = 2
+    @Published var exitWhenDone = true
+    @Published var hwLabel = ""
+    @Published var langLabel = ""
+    @Published var modified = false
+
+    var exitDelay = 3
+    var version = 2
+    var outputTypes: [String] = []
+    var extensions: [String] = []
+    var postActions = ["none", "archive", "delete"]
+    var hwLabels: [String] = []
+    var hwModes: [String] = []
+    var langLabels: [String] = []
+    var langCodes: [String] = []
+    var settingRows: [SettingRowSpec] = []
+    var newPresetTemplate: [String: Any] = [:]
+    @Published var strings: [String: String] = [:]
+
+    var selected: PresetVM? { presets.first { $0.id == selection } }
+
+    func handle(_ msg: [String: Any]) {
+        switch msg["type"] as? String {
+        case "init":
+            let meta = msg["meta"] as? [String: Any] ?? [:]
+            strings = meta["strings"] as? [String: String] ?? [:]
+            outputTypes = (meta["output_types"] as? [Any] ?? []).compactMap { $0 as? String }
+            extensions = (meta["extensions"] as? [Any] ?? []).compactMap { $0 as? String }
+            postActions = (meta["post_actions"] as? [Any] ?? []).compactMap { $0 as? String }
+            hwLabels = (meta["hw_labels"] as? [Any] ?? []).compactMap { $0 as? String }
+            hwModes = (meta["hw_modes"] as? [Any] ?? []).compactMap { $0 as? String }
+            langLabels = (meta["lang_labels"] as? [Any] ?? []).compactMap { $0 as? String }
+            langCodes = (meta["lang_codes"] as? [Any] ?? []).compactMap { $0 as? String }
+            settingRows = (meta["setting_rows"] as? [[String: Any]] ?? []).map { SettingRowSpec($0) }
+            newPresetTemplate = meta["new_preset"] as? [String: Any] ?? [:]
+
+            let s = msg["settings"] as? [String: Any] ?? [:]
+            version = (s["version"] as? NSNumber)?.intValue ?? 2
+            exitDelay = (s["exit_delay_seconds"] as? NSNumber)?.intValue ?? 3
+            maxJobs = (s["max_simultaneous_conversions"] as? NSNumber)?.intValue ?? 2
+            exitWhenDone = (s["exit_when_done"] as? NSNumber)?.boolValue ?? true
+            let hwMode = s["hardware_acceleration"] as? String ?? "off"
+            hwLabel = hwLabels.indices.contains(hwModes.firstIndex(of: hwMode) ?? -1)
+                ? hwLabels[hwModes.firstIndex(of: hwMode)!] : (hwLabels.first ?? "")
+            let lang = s["language"] as? String ?? "auto"
+            langLabel = langLabels.indices.contains(langCodes.firstIndex(of: lang) ?? -1)
+                ? langLabels[langCodes.firstIndex(of: lang)!] : (langLabels.first ?? "")
+            presets = (s["presets"] as? [[String: Any]] ?? []).map { PresetVM($0) }
+            selection = nil
+            modified = false
+            WindowRunner.shared.setTitle(str(strings, "title", "File Converter — Settings"))
+            IO.send(["ready": true])
+        case "saved":
+            modified = false
+            WindowRunner.shared.setTitle(str(strings, "title_saved", "File Converter — Settings (saved)"))
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                guard let self, !self.modified else { return }
+                WindowRunner.shared.setTitle(str(self.strings, "title", "File Converter — Settings"))
+            }
+        case "exit":
+            WindowRunner.shared.suppressCloseMessage = true
+            NSApp.terminate(nil)
+        default:
+            break
+        }
+    }
+
+    func markModified() {
+        if !modified {
+            modified = true
+            WindowRunner.shared.setTitle(str(strings, "title_modified", "File Converter — Settings *"))
+        }
+    }
+
+    func toDict() -> [String: Any] {
+        var hw = "off"
+        if let i = hwLabels.firstIndex(of: hwLabel), hwModes.indices.contains(i) { hw = hwModes[i] }
+        var lang = "auto"
+        if let i = langLabels.firstIndex(of: langLabel), langCodes.indices.contains(i) { lang = langCodes[i] }
+        return ["version": version,
+                "max_simultaneous_conversions": maxJobs,
+                "exit_when_done": exitWhenDone,
+                "exit_delay_seconds": exitDelay,
+                "hardware_acceleration": hw,
+                "language": lang,
+                "presets": presets.map { $0.toDict() }]
+    }
+
+    func save() { IO.send(["action": "save", "settings": toDict()]) }
+
+    func addPreset() {
+        let p = PresetVM(newPresetTemplate)
+        presets.append(p)
+        selection = p.id
+        markModified()
+    }
+
+    func removeSelected() {
+        guard let sel = selection, let idx = presets.firstIndex(where: { $0.id == sel }) else { return }
+        presets.remove(at: idx)
+        selection = nil
+        markModified()
+    }
+}
+
+struct PresetEditorView: View {
+    @ObservedObject var model: SettingsVM
+    @ObservedObject var preset: PresetVM
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text(str(model.strings, "name", "Name:"))
+                    TextField("", text: Binding(
+                        get: { preset.name },
+                        set: { preset.name = $0; model.markModified() }))
+                        .textFieldStyle(.roundedBorder)
+                }
+                HStack {
+                    Text(str(model.strings, "output", "Output:"))
+                    Picker("", selection: Binding(
+                        get: { preset.outputType },
+                        set: { preset.outputType = $0; model.markModified() })) {
+                        ForEach(model.outputTypes, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: 120)
+                    Spacer()
+                }
+
+                Text(str(model.strings, "input_types", "Input types:")).font(.headline)
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 70), alignment: .leading)],
+                          alignment: .leading, spacing: 4) {
+                    ForEach(model.extensions, id: \.self) { ext in
+                        Toggle(ext, isOn: Binding(
+                            get: { preset.inputTypes.contains(ext) },
+                            set: { on in
+                                if on { preset.inputTypes.insert(ext) }
+                                else { preset.inputTypes.remove(ext) }
+                                model.markModified()
+                            }))
+                            .toggleStyle(.checkbox)
+                            .font(.caption)
+                    }
+                }
+
+                Divider()
+                Text(str(model.strings, "conversion_settings", "Conversion settings:")).font(.headline)
+                ForEach(model.settingRows) { row in
+                    HStack {
+                        Text(row.label).frame(width: 200, alignment: .leading)
+                        switch row.kind {
+                        case "bool":
+                            Toggle("", isOn: preset.boolBinding(row) { model.markModified() })
+                                .labelsHidden()
+                                .toggleStyle(.checkbox)
+                        case "choice":
+                            Picker("", selection: preset.choiceBinding(row) { model.markModified() }) {
+                                ForEach(row.options, id: \.self) { Text($0).tag($0) }
+                            }
+                            .labelsHidden()
+                            .frame(maxWidth: 140)
+                        default:
+                            let binding = preset.numBinding(row) { model.markModified() }
+                            Stepper(value: binding, in: row.minV...row.maxV, step: row.step) {
+                                Text(row.kind == "float"
+                                     ? String(format: "%.2f", binding.wrappedValue)
+                                     : String(Int(binding.wrappedValue)))
+                                    .frame(minWidth: 52, alignment: .trailing)
+                                    .font(.system(.body, design: .monospaced))
+                            }
+                        }
+                        Spacer()
+                    }
+                }
+
+                Divider()
+                HStack {
+                    Text(str(model.strings, "after_conversion", "After conversion:"))
+                    Picker("", selection: Binding(
+                        get: { preset.postAction },
+                        set: { preset.postAction = $0; model.markModified() })) {
+                        ForEach(model.postActions, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: 130)
+                    Spacer()
+                }
+                HStack {
+                    Text(str(model.strings, "output_template", "Output template:"))
+                    TextField("", text: Binding(
+                        get: { preset.template },
+                        set: { preset.template = $0; model.markModified() }))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                }
+                Text(str(model.strings, "template_hint",
+                         "Variables: (p) path, (f) filename, (o) output ext, (i) input ext"))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(14)
+        }
+    }
+}
+
+struct SettingsWindowView: View {
+    @ObservedObject var model: SettingsVM
+
+    var body: some View {
+        HSplitView {
+            VStack(alignment: .leading, spacing: 8) {
+                GroupBox(label: Text(str(model.strings, "global", "Global"))) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Stepper(value: Binding(
+                            get: { model.maxJobs },
+                            set: { model.maxJobs = $0; model.markModified() }), in: 1...16) {
+                            Text("\(str(model.strings, "max_jobs", "Max jobs:")) \(model.maxJobs)")
+                        }
+                        Toggle(str(model.strings, "auto_close", "Auto-close when done"),
+                               isOn: Binding(
+                                get: { model.exitWhenDone },
+                                set: { model.exitWhenDone = $0; model.markModified() }))
+                            .toggleStyle(.checkbox)
+                        HStack {
+                            Text(str(model.strings, "gpu_accel", "GPU accel:"))
+                            Picker("", selection: Binding(
+                                get: { model.hwLabel },
+                                set: { model.hwLabel = $0; model.markModified() })) {
+                                ForEach(model.hwLabels, id: \.self) { Text($0).tag($0) }
+                            }
+                            .labelsHidden()
+                        }
+                        HStack {
+                            Text(str(model.strings, "language", "Language:"))
+                            Picker("", selection: Binding(
+                                get: { model.langLabel },
+                                set: { model.langLabel = $0; model.save() })) {
+                                ForEach(model.langLabels, id: \.self) { Text($0).tag($0) }
+                            }
+                            .labelsHidden()
+                        }
+                    }
+                    .padding(4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Text(str(model.strings, "presets", "Presets")).font(.headline)
+                List(model.presets, selection: $model.selection) { preset in
+                    PresetListRow(preset: preset)
+                }
+                HStack {
+                    Button(str(model.strings, "add", "Add")) { model.addPreset() }
+                    Button(str(model.strings, "remove", "Remove")) { model.removeSelected() }
+                    Spacer()
+                    Button(str(model.strings, "save", "Save")) { model.save() }
+                        .keyboardShortcut("s", modifiers: .command)
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(10)
+            .frame(minWidth: 270, maxWidth: 360)
+
+            Group {
+                if let preset = model.selected {
+                    PresetEditorView(model: model, preset: preset)
+                } else {
+                    Text(str(model.strings, "select_preset", "Select a preset to edit"))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .frame(minWidth: 380, maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(minWidth: 720, minHeight: 480)
+    }
+}
+
+struct PresetListRow: View {
+    @ObservedObject var preset: PresetVM
+    var body: some View {
+        Text(preset.name).tag(preset.id)
+    }
+}
+
+// MARK: - Entry point
+
+@main
+struct Main {
+    static func main() {
+        signal(SIGPIPE, SIG_IGN)
+        let mode = CommandLine.arguments.dropFirst().first ?? "progress"
+
+        switch mode {
+        case "pick":
+            let model = PickVM()
+            IO.readLoop { model.handle($0) }
+            WindowRunner.shared.run(title: "File Converter", width: 430, height: 540,
+                                    minW: 380, minH: 300,
+                                    view: PickWindowView(model: model))
+        case "settings":
+            let model = SettingsVM()
+            IO.readLoop { model.handle($0) }
+            WindowRunner.shared.run(title: "File Converter — Settings", width: 880, height: 640,
+                                    minW: 720, minH: 480,
+                                    view: SettingsWindowView(model: model))
+        default:
+            let model = ProgressVM()
+            IO.readLoop { model.handle($0) }
+            WindowRunner.shared.run(title: "File Converter", width: 560, height: 420,
+                                    minW: 480, minH: 240,
+                                    view: ProgressWindowView(model: model))
+        }
+    }
+}

--- a/fileconverter/ui/native/FinderSyncExt.swift
+++ b/fileconverter/ui/native/FinderSyncExt.swift
@@ -1,0 +1,119 @@
+// FinderSyncExt — Finder Sync extension: puts a real "File Converter"
+// submenu in Finder's right-click menu, exactly like the Dolphin/Nemo
+// submenus on Linux.
+//
+// The preset list (and its translations) comes from menu.json, written by
+// the Python side on every install/settings save, so the menu never drifts
+// from the config. Filtering happens HERE, per extension — no UTI matching
+// involved, so .mkv & friends always get the right entries.
+//
+// Menu clicks never spawn work directly: they open a fileconverter:// URL,
+// handled by the (unsandboxed) host app, which runs the usual launcher —
+// same code path as the terminal and the Quick Actions.
+
+import AppKit
+import FinderSync
+import Foundation
+
+struct MenuPreset {
+    let name: String
+    let short: String
+    let extensions: Set<String>
+}
+
+final class FinderSync: FIFinderSync {
+
+    override init() {
+        super.init()
+        // Whole filesystem: the converter is meaningful anywhere.
+        FIFinderSyncController.default().directoryURLs = [URL(fileURLWithPath: "/")]
+    }
+
+    // MARK: menu.json
+
+    private var menuConfigURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/fileconverter/menu.json")
+    }
+
+    private func loadConfig() -> (presets: [MenuPreset], strings: [String: String]) {
+        guard let data = try? Data(contentsOf: menuConfigURL),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return ([], [:]) }
+        let strings = obj["strings"] as? [String: String] ?? [:]
+        let presets = (obj["presets"] as? [[String: Any]] ?? []).compactMap { p -> MenuPreset? in
+            guard let name = p["name"] as? String else { return nil }
+            let exts = (p["extensions"] as? [Any] ?? []).compactMap { ($0 as? String)?.lowercased() }
+            return MenuPreset(name: name,
+                              short: p["short"] as? String ?? name,
+                              extensions: Set(exts))
+        }
+        return (presets, strings)
+    }
+
+    // MARK: Context menu
+
+    override func menu(for menuKind: FIMenuKind) -> NSMenu? {
+        guard menuKind == .contextualMenuForItems else { return nil }
+        let selected = FIFinderSyncController.default().selectedItemURLs() ?? []
+        guard !selected.isEmpty else { return nil }
+
+        // Only offer presets that accept EVERY selected file (Linux rule).
+        var exts = Set<String>()
+        for url in selected {
+            let e = url.pathExtension.lowercased()
+            if e.isEmpty { return nil }   // folders / extension-less files
+            exts.insert(e)
+        }
+
+        let (presets, strings) = loadConfig()
+        let compatible = presets.filter { exts.isSubset(of: $0.extensions) }
+        guard !compatible.isEmpty else { return nil }
+
+        let submenu = NSMenu(title: "")
+        for preset in compatible {
+            let item = NSMenuItem(title: preset.short,
+                                  action: #selector(convertAction(_:)),
+                                  keyEquivalent: "")
+            item.target = self
+            item.representedObject = preset.name
+            submenu.addItem(item)
+        }
+        submenu.addItem(.separator())
+        let configure = NSMenuItem(title: strings["configure"] ?? "Configure presets...",
+                                   action: #selector(configureAction(_:)),
+                                   keyEquivalent: "")
+        configure.target = self
+        submenu.addItem(configure)
+
+        let root = NSMenuItem(title: strings["menu_title"] ?? "File Converter",
+                              action: nil, keyEquivalent: "")
+        root.submenu = submenu
+        let menu = NSMenu(title: "")
+        menu.addItem(root)
+        return menu
+    }
+
+    // MARK: Actions → fileconverter:// URL → host app
+
+    @objc private func convertAction(_ sender: NSMenuItem) {
+        guard let preset = sender.representedObject as? String else { return }
+        let files = FIFinderSyncController.default().selectedItemURLs() ?? []
+        guard !files.isEmpty else { return }
+        var comps = URLComponents()
+        comps.scheme = "fileconverter"
+        comps.host = "convert"
+        var items = [URLQueryItem(name: "preset", value: preset)]
+        items += files.map { URLQueryItem(name: "f", value: $0.path) }
+        comps.queryItems = items
+        if let url = comps.url {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    @objc private func configureAction(_ sender: NSMenuItem) {
+        if let url = URL(string: "fileconverter://settings") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}

--- a/fileconverter/ui/native/HostApp.swift
+++ b/fileconverter/ui/native/HostApp.swift
@@ -1,0 +1,106 @@
+// FileConverterHost — the tiny background app inside "File Converter.app".
+//
+// Two jobs:
+//   1. Handle fileconverter:// URLs sent by the Finder Sync extension
+//      (fileconverter://convert?preset=To%20Mp4&f=/path/a.mkv&f=/path/b.mkv
+//       and fileconverter://settings) by running the regular launcher.
+//   2. On a plain double-click launch (no URL), open the settings window —
+//      this app doubles as the Dock-visible settings entry.
+//
+// It is deliberately NOT sandboxed: the sandboxed Finder extension delegates
+// here so conversions run with normal file access.
+//
+// The app stays alive until every spawned conversion exits. That is not
+// cosmetic: as long as this app is the running "responsible process", TCC
+// folder prompts (Downloads, Desktop, Documents...) are asked — and stored —
+// in the name of "File Converter", not of the venv's "python3.x" binary.
+
+import AppKit
+import Foundation
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var handledURL = false
+    private var activeChildren = 0
+
+    private var launcher: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/bin/fileconverter").path
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        handledURL = true
+        for url in urls {
+            handle(url)
+        }
+        scheduleQuitIfIdle()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // URL opens arrive right after launch; give them a moment before
+        // deciding this was a plain double-click.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            guard let self, !self.handledURL else { return }
+            self.spawn([self.launcher, "--settings"])
+            self.scheduleQuitIfIdle()
+        }
+    }
+
+    private func handle(_ url: URL) {
+        guard url.scheme == "fileconverter" else { return }
+        switch url.host {
+        case "convert":
+            let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let items = comps?.queryItems ?? []
+            guard let preset = items.first(where: { $0.name == "preset" })?.value,
+                  !preset.isEmpty else { return }
+            let files = items.filter { $0.name == "f" }.compactMap { $0.value }
+            guard !files.isEmpty else { return }
+            spawn([launcher, "--conversion-preset", preset] + files)
+        case "settings":
+            spawn([launcher, "--settings"])
+        default:
+            break
+        }
+    }
+
+    private func spawn(_ argv: [String]) {
+        guard let exe = argv.first, FileManager.default.isExecutableFile(atPath: exe) else { return }
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: exe)
+        proc.arguments = Array(argv.dropFirst())
+        do {
+            try proc.run()
+        } catch {
+            NSLog("FileConverterHost: failed to run \(exe): \(error)")
+            return
+        }
+        // Stay alive (and TCC-responsible) until this child finishes.
+        activeChildren += 1
+        DispatchQueue.global().async {
+            proc.waitUntilExit()
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.activeChildren -= 1
+                self.scheduleQuitIfIdle()
+            }
+        }
+    }
+
+    private func scheduleQuitIfIdle() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            if self.activeChildren == 0 {
+                NSApp.terminate(nil)
+            }
+        }
+    }
+}
+
+@main
+struct HostMain {
+    static func main() {
+        let app = NSApplication.shared
+        let delegate = AppDelegate()
+        app.delegate = delegate
+        app.run()
+    }
+}

--- a/fileconverter/ui/native_ui.py
+++ b/fileconverter/ui/native_ui.py
@@ -1,0 +1,433 @@
+"""Driver for the native SwiftUI front-end (macOS).
+
+Spawns `fileconverter-ui` (compiled at install time from
+fileconverter/ui/native/FileConverterUI.swift) and drives it over a
+JSON-lines protocol. Everything that matters — conversions, ETA math,
+auto-close timing, translations — stays in Python; the Swift binary only
+renders. If the binary is missing or misbehaves before conversions start,
+callers fall back to the tkinter UI, then headless.
+"""
+
+from __future__ import annotations
+import json
+import os
+import queue
+import subprocess
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from fileconverter import i18n
+from fileconverter.config import (
+    HWACCEL_LABELS, HWACCEL_MODES, Settings, load_settings, save_settings,
+)
+from fileconverter.i18n import _
+from fileconverter.jobs.base import ConversionJob, ConversionState
+
+UI_BIN = Path.home() / ".local" / "share" / "fileconverter" / "bin" / "fileconverter-ui"
+
+_POLL = 0.2
+
+
+class NativeUIUnavailable(RuntimeError):
+    pass
+
+
+def available() -> bool:
+    return UI_BIN.exists() and os.access(UI_BIN, os.X_OK)
+
+
+def _spawn(mode: str) -> subprocess.Popen:
+    if not available():
+        raise NativeUIUnavailable("fileconverter-ui is not built")
+    try:
+        return subprocess.Popen(
+            [str(UI_BIN), mode],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            text=True, bufsize=1,
+        )
+    except OSError as e:
+        raise NativeUIUnavailable(str(e))
+
+
+def _send(proc: subprocess.Popen, obj: dict) -> bool:
+    try:
+        proc.stdin.write(json.dumps(obj) + "\n")
+        proc.stdin.flush()
+        return True
+    except (BrokenPipeError, OSError, ValueError):
+        return False
+
+
+def _start_reader(proc: subprocess.Popen) -> queue.Queue:
+    q: queue.Queue = queue.Queue()
+
+    def _read():
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    q.put(json.loads(line))
+                except ValueError:
+                    pass
+        except (OSError, ValueError):
+            pass
+        q.put(None)  # EOF sentinel
+
+    threading.Thread(target=_read, daemon=True).start()
+    return q
+
+
+def _handshake(proc: subprocess.Popen, q: queue.Queue, init: dict,
+               timeout: float = 8.0) -> None:
+    """Send init and wait for {"ready": true}. Raising here is safe — no
+    conversion has started yet, so the caller can fall back to another UI."""
+    if not _send(proc, init):
+        _kill(proc)
+        raise NativeUIUnavailable("could not talk to the UI process")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            msg = q.get(timeout=0.2)
+        except queue.Empty:
+            if proc.poll() is not None:
+                raise NativeUIUnavailable("UI process exited during startup")
+            continue
+        if msg is None:
+            raise NativeUIUnavailable("UI closed its output during startup")
+        if msg.get("ready"):
+            return
+    _kill(proc)
+    raise NativeUIUnavailable("UI startup timed out")
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    try:
+        if proc.stdin:
+            proc.stdin.close()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+# ── Progress window ──
+
+def _progress_text(job: ConversionJob) -> str:
+    """Percent + ETA text — same math as the GTK/tkinter windows."""
+    progress = job.progress
+    elapsed = time.time() - job.start_time if job.start_time else 0
+    if job.state == ConversionState.DONE:
+        return _("Complete")
+    if job.state == ConversionState.FAILED:
+        return _("Failed")
+    if progress > 0.01 and elapsed > 1:
+        eta = (elapsed / progress) * (1 - progress)
+        if eta < 60:
+            eta_str = _("{seconds}s remaining").format(seconds=int(eta))
+        else:
+            eta_str = _("{minutes}m {seconds}s remaining").format(
+                minutes=int(eta // 60), seconds=int(eta % 60))
+        return f"{progress * 100:.0f}% — {eta_str}"
+    return f"{progress * 100:.0f}%"
+
+
+def _job_status(job: ConversionJob) -> str:
+    if job.state == ConversionState.DONE:
+        return f"→ {os.path.basename(job.output_path)}"
+    if job.state == ConversionState.FAILED:
+        return job.error_message or _("Unknown error")
+    if job.state == ConversionState.READY:
+        return _("Queued...")
+    return job.user_state
+
+
+def _summary_status(jobs: list) -> str:
+    failed = sum(1 for j in jobs if j.state == ConversionState.FAILED)
+    done = sum(1 for j in jobs if j.state == ConversionState.DONE)
+    total = len(jobs)
+    if failed:
+        return _("{done}/{total} completed, {failed} failed").format(
+            done=done, total=total, failed=failed)
+    return _("{done}/{total} completed").format(done=done, total=total)
+
+
+def run_with_progress(jobs: list, settings: Settings) -> None:
+    proc = _spawn("progress")
+    q = _start_reader(proc)
+    init = {
+        "type": "init",
+        "title": "File Converter",
+        "jobs": [{"id": i, "name": j.input_filename,
+                  "out": j.preset.output_type.upper()}
+                 for i, j in enumerate(jobs)],
+        "strings": {
+            "cancel": _("Cancel"),
+            "cancelling": _("Cancelling..."),
+            "keep_open": _("Keep open"),
+            "waiting": _("Waiting..."),
+        },
+    }
+    _handshake(proc, q, init)
+
+    # UI confirmed — safe to start converting now.
+    def _prepare_and_run(job: ConversionJob):
+        try:
+            job.prepare()
+            job.run()
+        except Exception as e:
+            job.state = ConversionState.FAILED
+            job.error_message = str(e)
+
+    def _worker():
+        with ThreadPoolExecutor(
+                max_workers=settings.max_simultaneous_conversions) as pool:
+            pool.map(_prepare_and_run, jobs)
+
+    threading.Thread(target=_worker, daemon=True).start()
+
+    last_sent: dict = {}
+    close_at = None      # auto-close deadline (time.time())
+    keep_open = False
+    summary_shown = False
+
+    def _push_updates() -> bool:
+        alive = True
+        for i, job in enumerate(jobs):
+            payload = {
+                "type": "update", "id": i,
+                "progress": round(min(job.progress, 1.0), 3),
+                "state": job.state.value,
+                "progress_text": _progress_text(job),
+                "status": _job_status(job),
+            }
+            if last_sent.get(i) != payload:
+                last_sent[i] = payload
+                if not _send(proc, payload):
+                    alive = False
+        return alive
+
+    try:
+        while True:
+            # Drain UI events
+            ui_gone = False
+            while True:
+                try:
+                    msg = q.get_nowait()
+                except queue.Empty:
+                    break
+                if msg is None or msg.get("closed"):
+                    ui_gone = True
+                    break
+                if "cancel" in msg:
+                    idx = msg["cancel"]
+                    if isinstance(idx, int) and 0 <= idx < len(jobs):
+                        jobs[idx].request_cancel()
+                if msg.get("keep_open"):
+                    keep_open = True
+                    close_at = None
+                    _send(proc, {"type": "summary",
+                                 "text": _summary_status(jobs),
+                                 "show_keep_open": False})
+
+            if ui_gone:
+                # Window closed — stop pending/running jobs (their run loop
+                # kills the ffmpeg/magick subprocess) and give them a moment.
+                for job in jobs:
+                    if job.state not in (ConversionState.DONE, ConversionState.FAILED):
+                        job.request_cancel()
+                time.sleep(0.4)
+                return
+
+            if not _push_updates():
+                return
+
+            all_done = all(j.state in (ConversionState.DONE, ConversionState.FAILED)
+                           for j in jobs)
+            if all_done:
+                if not summary_shown:
+                    summary_shown = True
+                    if settings.exit_when_done and not keep_open:
+                        close_at = time.time() + settings.exit_delay_seconds
+                    else:
+                        _send(proc, {"type": "summary",
+                                     "text": _summary_status(jobs),
+                                     "show_keep_open": False})
+                if close_at is not None:
+                    remaining = int(round(close_at - time.time()))
+                    if remaining <= 0:
+                        _send(proc, {"type": "exit"})
+                        return
+                    _send(proc, {"type": "summary",
+                                 "text": _("{status} — closing in {seconds}s").format(
+                                     status=_summary_status(jobs), seconds=remaining),
+                                 "show_keep_open": True})
+
+            time.sleep(_POLL)
+    finally:
+        _kill(proc)
+
+
+# ── Settings window ──
+
+def _settings_payload(settings: Settings) -> dict:
+    from fileconverter.helpers import (
+        ALL_INPUT_EXTENSIONS, OUTPUT_TYPES, VIDEO_CODECS,
+    )
+    speeds = ["ultrafast", "superfast", "veryfast", "faster", "fast",
+              "medium", "slow", "slower", "veryslow"]
+    detected = i18n.detect_system_language() or ""
+    detected_label = dict(i18n.SUPPORTED_LANGUAGES).get(detected)
+    auto_label = (_("System default ({name})").format(name=detected_label)
+                  if detected_label else _("System default"))
+    lang_labels = [auto_label] + [
+        label for code, label in i18n.SUPPORTED_LANGUAGES if code != "auto"]
+
+    # Mirrors the GTK editor's common_settings table.
+    setting_rows = [
+        {"key": "video_codec", "label": _("Video Codec"),
+         "kind": "choice", "options": VIDEO_CODECS},
+        {"key": "video_quality", "label": _("Video Quality (0-63)"),
+         "kind": "int", "min": 0, "max": 63, "default": 28},
+        {"key": "video_encoding_speed", "label": _("Encoding Speed"),
+         "kind": "choice", "options": speeds},
+        {"key": "video_scale", "label": _("Video Scale"),
+         "kind": "float", "min": 0.1, "max": 4.0, "step": 0.1, "default": 1.0},
+        {"key": "video_rotation", "label": _("Rotation (degrees)"),
+         "kind": "int", "min": 0, "max": 270, "default": 0},
+        {"key": "audio_bitrate", "label": _("Audio Bitrate"),
+         "kind": "int", "min": 16, "max": 500, "default": 155},
+        {"key": "image_quality", "label": _("Image Quality (0-100)"),
+         "kind": "int", "min": 0, "max": 100, "default": 85},
+        {"key": "image_scale", "label": _("Image Scale"),
+         "kind": "float", "min": 0.1, "max": 4.0, "step": 0.1, "default": 1.0},
+        {"key": "enable_audio", "label": _("Enable Audio"),
+         "kind": "bool", "default": True},
+    ]
+    return {
+        "type": "init",
+        "settings": settings.to_dict(),
+        "meta": {
+            "output_types": OUTPUT_TYPES,
+            "extensions": ALL_INPUT_EXTENSIONS,
+            "post_actions": ["none", "archive", "delete"],
+            "hw_labels": [_(label) for label in HWACCEL_LABELS],
+            "hw_modes": HWACCEL_MODES,
+            "lang_labels": lang_labels,
+            "lang_codes": i18n.LANGUAGE_CODES,
+            "setting_rows": setting_rows,
+            "new_preset": {
+                "name": _("New Preset"),
+                "output_type": "mp4",
+                "input_types": ["avi", "mkv", "mov", "mp4", "webm"],
+                "input_post_action": "none",
+                "output_template": "(p)(f)",
+                "settings": {"enable_audio": True, "video_quality": 28,
+                             "video_encoding_speed": "medium",
+                             "audio_bitrate": 155, "video_scale": 1.0},
+            },
+            "strings": {
+                "title": _("File Converter — Settings"),
+                "title_modified": _("File Converter — Settings *"),
+                "title_saved": _("File Converter — Settings (saved)"),
+                "global": _("Global"),
+                "presets": _("Presets"),
+                "add": _("Add"),
+                "remove": _("Remove"),
+                "save": _("Save"),
+                "name": _("Name:"),
+                "output": _("Output:"),
+                "input_types": _("Input types:"),
+                "conversion_settings": _("Conversion settings:"),
+                "after_conversion": _("After conversion:"),
+                "output_template": _("Output template:"),
+                "template_hint": _("Variables: (p) path, (f) filename, (o) output ext, (i) input ext"),
+                "max_jobs": _("Max jobs:"),
+                "auto_close": _("Auto-close when done"),
+                "gpu_accel": _("GPU accel:"),
+                "language": _("Language:"),
+                "select_preset": _("Select a preset to edit"),
+            },
+        },
+    }
+
+
+def run_settings() -> None:
+    settings = load_settings()
+    i18n.init(settings.language)
+
+    proc = _spawn("settings")
+    q = _start_reader(proc)
+    _handshake(proc, q, _settings_payload(settings))
+
+    try:
+        while True:
+            msg = q.get()
+            if msg is None or msg.get("closed"):
+                return
+            if msg.get("action") == "save":
+                data = msg.get("settings") or {}
+                old_lang = settings.language
+                data.setdefault("version", settings.version)
+                data.setdefault("exit_delay_seconds", settings.exit_delay_seconds)
+                settings = Settings.from_dict(data)
+                save_settings(settings)
+                try:
+                    from fileconverter.integration.macos import refresh_services
+                    refresh_services(quiet=True)
+                except Exception:
+                    pass
+                if settings.language != old_lang:
+                    i18n.init(settings.language)
+                    # Full re-init so every label picks up the new language
+                    # (the GTK/tkinter windows rebuild themselves the same way).
+                    _send(proc, _settings_payload(settings))
+                else:
+                    _send(proc, {"type": "saved"})
+    finally:
+        _kill(proc)
+
+
+# ── Preset picker ──
+
+def run_picker(file_paths: list, compatible_presets: list,
+               on_choice) -> None:
+    """Show the native picker; call on_choice(preset_name) if one is chosen."""
+    n = len(file_paths)
+    info = (_("{count} file selected") if n == 1
+            else _("{count} files selected")).format(count=n)
+    init = {
+        "type": "init",
+        "title": _("File Converter — Select Preset"),
+        "info": info,
+        "presets": [{
+            "name": p["name"],
+            "short": p["name"].split("/")[-1],
+            "folder": "/".join(p["name"].split("/")[:-1]),
+            "out": p.get("output_type", "").upper(),
+        } for p in compatible_presets],
+        "strings": {"convert": _("Convert")},
+    }
+    proc = _spawn("pick")
+    q = _start_reader(proc)
+    _handshake(proc, q, init)
+    try:
+        while True:
+            msg = q.get()
+            if msg is None or msg.get("closed"):
+                return
+            preset = msg.get("preset")
+            if preset:
+                on_choice(preset)
+                return
+    finally:
+        _kill(proc)

--- a/fileconverter/ui/picker.py
+++ b/fileconverter/ui/picker.py
@@ -1,0 +1,94 @@
+"""Preset picker entry point — native SwiftUI on macOS, tkinter fallback.
+
+Usage: fileconverter-pick file1.avi file2.mkv
+(backs the generic "File Converter…" Quick Action on macOS)
+"""
+
+from __future__ import annotations
+import os
+import shutil
+import subprocess
+import sys
+
+from fileconverter import i18n
+
+
+def _find_fileconverter() -> str:
+    for path in [
+        os.path.expanduser("~/.local/bin/fileconverter"),
+        "/usr/local/bin/fileconverter",
+        "/usr/bin/fileconverter",
+    ]:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return shutil.which("fileconverter") or ""
+
+
+def _launch_conversion(preset_name: str, file_paths: list) -> None:
+    # On macOS, route through File Converter.app when it exists: the app
+    # stays alive for the conversion, so TCC folder prompts (Downloads,
+    # Desktop, ...) are attributed to "File Converter" instead of python3.x.
+    if sys.platform == "darwin":
+        host_app = os.path.expanduser("~/Applications/File Converter.app")
+        if os.path.isdir(host_app):
+            from urllib.parse import quote
+            url = ("fileconverter://convert?preset=" + quote(preset_name)
+                   + "".join("&f=" + quote(p) for p in file_paths))
+            try:
+                subprocess.run(["open", url], check=True, timeout=30)
+                return
+            except (subprocess.SubprocessError, OSError):
+                pass  # fall back to the direct spawn below
+
+    fc = _find_fileconverter()
+    if fc:
+        cmd = [fc, "--conversion-preset", preset_name] + file_paths
+    else:
+        cmd = [sys.executable, "-m", "fileconverter",
+               "--conversion-preset", preset_name] + file_paths
+    subprocess.Popen(cmd, start_new_session=True)
+
+
+def main() -> None:
+    files = sys.argv[1:]
+    if not files:
+        print("Usage: fileconverter-pick file1 file2 ...", file=sys.stderr)
+        sys.exit(1)
+    file_paths = [os.path.abspath(f) for f in files]
+
+    from fileconverter.config import load_settings
+    settings = load_settings()
+    i18n.init(settings.language)
+
+    extensions = set()
+    for f in file_paths:
+        ext = os.path.splitext(f)[1]
+        if ext:
+            extensions.add(ext.lower().lstrip("."))
+    compatible = [p.to_dict() for p in settings.presets
+                  if all(ext in p.input_types for ext in extensions)]
+
+    if sys.platform == "darwin":
+        try:
+            from fileconverter.ui import native_ui
+            if native_ui.available():
+                if not compatible:
+                    from fileconverter.ui import notify
+                    from fileconverter.i18n import _
+                    notify(_("No compatible presets"),
+                           _("No presets support all selected file types: {types}").format(
+                               types=", ".join(sorted(extensions))))
+                    return
+                native_ui.run_picker(
+                    file_paths, compatible,
+                    lambda preset: _launch_conversion(preset, file_paths))
+                return
+        except Exception:
+            pass  # fall through to tkinter
+
+    from fileconverter.ui import preset_picker_tk
+    preset_picker_tk.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/fileconverter/ui/preset_picker_tk.py
+++ b/fileconverter/ui/preset_picker_tk.py
@@ -1,0 +1,140 @@
+"""tkinter preset picker — feature-parity port of preset_picker.py (GTK).
+
+Shows a filtered list of compatible presets for the selected files. On macOS
+this backs the generic "File Converter…" Quick Action; on Linux it serves
+file managers without submenu support when GTK is missing.
+
+Usage: fileconverter-pick file1.avi file2.mkv
+"""
+
+from __future__ import annotations
+import os
+import shutil
+import subprocess
+import sys
+import tkinter as tk
+from tkinter import messagebox, ttk
+
+from fileconverter import i18n
+from fileconverter.i18n import _
+
+
+def _find_fileconverter() -> str | None:
+    for path in [
+        os.path.expanduser("~/.local/bin/fileconverter"),
+        "/usr/local/bin/fileconverter",
+        "/usr/bin/fileconverter",
+    ]:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return shutil.which("fileconverter")
+
+
+class PresetPickerWindow:
+    def __init__(self, root: tk.Tk, file_paths: list, presets: list):
+        self.root = root
+        self.file_paths = file_paths
+        self.presets = presets
+
+        root.title(_("File Converter — Select Preset"))
+        root.geometry("420x520")
+        root.minsize(360, 300)
+
+        n = len(file_paths)
+        if n == 1:
+            info_text = _("{count} file selected").format(count=n)
+        else:
+            info_text = _("{count} files selected").format(count=n)
+        ttk.Label(root, text=info_text, foreground="gray",
+                  padding=(12, 10, 12, 6)).pack(anchor="w")
+
+        container = ttk.Frame(root)
+        container.pack(fill="both", expand=True)
+        canvas = tk.Canvas(container, highlightthickness=0)
+        scrollbar = ttk.Scrollbar(container, orient="vertical",
+                                  command=canvas.yview)
+        inner = ttk.Frame(canvas)
+        inner.bind("<Configure>",
+                   lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+        window = canvas.create_window((0, 0), window=inner, anchor="nw")
+        canvas.bind("<Configure>",
+                    lambda e: canvas.itemconfigure(window, width=e.width))
+        canvas.configure(yscrollcommand=scrollbar.set)
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
+        current_folder = None
+        for preset_data in presets:
+            name = preset_data.get("name", "")
+            parts = name.split("/")
+            folder = "/".join(parts[:-1]) if len(parts) > 1 else ""
+            short_name = parts[-1]
+
+            if folder and folder != current_folder:
+                current_folder = folder
+                ttk.Label(inner, text=folder, padding=(12, 8, 12, 2)).pack(anchor="w")
+
+            row = ttk.Frame(inner, padding=(12, 3))
+            row.pack(fill="x")
+            row.columnconfigure(0, weight=1)
+            ttk.Label(row, text=short_name, anchor="w").grid(
+                row=0, column=0, sticky="ew")
+            ttk.Label(row, text=preset_data.get("output_type", "").upper(),
+                      foreground="gray").grid(row=0, column=1, padx=8)
+            ttk.Button(row, text=_("Convert"),
+                       command=lambda nm=name: self._on_convert(nm)).grid(
+                row=0, column=2)
+
+    def _on_convert(self, preset_name: str):
+        fc = _find_fileconverter()
+        if fc:
+            cmd = [fc, "--conversion-preset", preset_name] + self.file_paths
+        else:
+            cmd = [sys.executable, "-m", "fileconverter",
+                   "--conversion-preset", preset_name] + self.file_paths
+        subprocess.Popen(cmd, start_new_session=True)
+        self.root.destroy()
+
+
+def main():
+    files = sys.argv[1:]
+    if not files:
+        print("Usage: fileconverter-pick file1 file2 ...", file=sys.stderr)
+        sys.exit(1)
+    file_paths = [os.path.abspath(f) for f in files]
+
+    from fileconverter.config import load_settings
+    settings = load_settings()
+    i18n.init(settings.language)
+
+    extensions = set()
+    for f in file_paths:
+        ext = os.path.splitext(f)[1]
+        if ext:
+            extensions.add(ext.lower().lstrip("."))
+    compatible = [p.to_dict() for p in settings.presets
+                  if all(ext in p.input_types for ext in extensions)]
+
+    root = tk.Tk()
+    if sys.platform == "darwin":
+        try:
+            root.lift()
+            root.attributes("-topmost", True)
+            root.after(700, lambda: root.attributes("-topmost", False))
+        except tk.TclError:
+            pass
+
+    if not compatible:
+        root.withdraw()
+        messagebox.showinfo(
+            _("No compatible presets"),
+            _("No presets support all selected file types: {types}").format(
+                types=", ".join(sorted(extensions))))
+        return
+
+    PresetPickerWindow(root, file_paths, compatible)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/fileconverter/ui/progress_window_tk.py
+++ b/fileconverter/ui/progress_window_tk.py
@@ -1,0 +1,261 @@
+"""tkinter progress window — feature-parity port of progress_window.py (GTK).
+
+Used on macOS (which has no GTK) and as a fallback on Linux systems without
+GTK 4 (GH #5). Same model as the GTK window: worker threads mutate the job
+objects, the UI polls them every 200 ms from the Tk main loop.
+"""
+
+from __future__ import annotations
+import os
+import sys
+import threading
+import time
+import tkinter as tk
+from concurrent.futures import ThreadPoolExecutor
+from tkinter import ttk
+
+from fileconverter.config import Settings
+from fileconverter.i18n import _
+from fileconverter.jobs.base import ConversionJob, ConversionState
+
+_POLL_MS = 200
+
+
+def _middle_ellipsis(text: str, max_len: int = 48) -> str:
+    if len(text) <= max_len:
+        return text
+    half = (max_len - 1) // 2
+    return text[:half] + "…" + text[-half:]
+
+
+class JobRow(ttk.Frame):
+    """A single row showing one conversion job's progress."""
+
+    def __init__(self, parent, job: ConversionJob):
+        super().__init__(parent, padding=(12, 6))
+        self.job = job
+        self.columnconfigure(0, weight=1)
+
+        top = ttk.Frame(self)
+        top.grid(row=0, column=0, sticky="ew")
+        top.columnconfigure(0, weight=1)
+
+        self.filename_label = ttk.Label(
+            top, text=_middle_ellipsis(job.input_filename), anchor="w")
+        try:
+            import tkinter.font as tkfont
+            bold = tkfont.nametofont("TkDefaultFont").copy()
+            bold.configure(weight="bold")
+            self.filename_label.configure(font=bold)
+        except Exception:
+            pass
+        self.filename_label.grid(row=0, column=0, sticky="ew")
+
+        self.output_label = ttk.Label(
+            top, text=f"→ {job.preset.output_type.upper()}", foreground="gray")
+        self.output_label.grid(row=0, column=1, padx=8)
+
+        self.cancel_btn = ttk.Button(top, text=_("Cancel"), command=self._on_cancel)
+        self.cancel_btn.grid(row=0, column=2)
+
+        bar_row = ttk.Frame(self)
+        bar_row.grid(row=1, column=0, sticky="ew", pady=(4, 0))
+        bar_row.columnconfigure(0, weight=1)
+        self.progress_bar = ttk.Progressbar(bar_row, maximum=1.0, value=0.0)
+        self.progress_bar.grid(row=0, column=0, sticky="ew")
+        # Aqua progress bars can't draw text on themselves — separate label.
+        self.progress_text = ttk.Label(bar_row, text="0%", width=24, anchor="e")
+        self.progress_text.grid(row=0, column=1, padx=(8, 0))
+
+        self.status_label = ttk.Label(self, text=_("Waiting..."), foreground="gray")
+        self.status_label.grid(row=2, column=0, sticky="w", pady=(2, 0))
+
+        ttk.Separator(self, orient="horizontal").grid(
+            row=3, column=0, sticky="ew", pady=(6, 0))
+
+    def _on_cancel(self):
+        self.job.request_cancel()
+        self.cancel_btn.state(["disabled"])
+        self.cancel_btn.configure(text=_("Cancelling..."))
+
+    def update_row(self) -> None:
+        state = self.job.state
+        progress = self.job.progress
+        self.progress_bar.configure(value=min(progress, 1.0))
+
+        if state == ConversionState.IN_PROGRESS:
+            elapsed = time.time() - self.job.start_time if self.job.start_time else 0
+            if progress > 0.01 and elapsed > 1:
+                eta = (elapsed / progress) * (1 - progress)
+                if eta < 60:
+                    eta_str = _("{seconds}s remaining").format(seconds=int(eta))
+                else:
+                    eta_str = _("{minutes}m {seconds}s remaining").format(
+                        minutes=int(eta // 60), seconds=int(eta % 60))
+                self.progress_text.configure(text=f"{progress * 100:.0f}% — {eta_str}")
+            else:
+                self.progress_text.configure(text=f"{progress * 100:.0f}%")
+            self.status_label.configure(text=self.job.user_state)
+        elif state == ConversionState.DONE:
+            self.progress_bar.configure(value=1.0)
+            self.progress_text.configure(text=_("Complete"))
+            self.status_label.configure(
+                text=f"→ {os.path.basename(self.job.output_path)}")
+            self.cancel_btn.grid_remove()
+        elif state == ConversionState.FAILED:
+            self.progress_text.configure(text=_("Failed"))
+            self.status_label.configure(
+                text=self.job.error_message or _("Unknown error"), foreground="#c0392b")
+            self.cancel_btn.grid_remove()
+        elif state == ConversionState.READY:
+            self.status_label.configure(text=_("Queued..."))
+
+
+class ProgressWindow:
+    """Main window showing all conversion jobs."""
+
+    def __init__(self, root: tk.Tk, jobs: list, settings: Settings):
+        self.root = root
+        self.jobs = jobs
+        self.settings = settings
+        self.job_rows: list[JobRow] = []
+        self._auto_close_job = None
+        self._auto_close_seconds = settings.exit_delay_seconds
+        self._auto_closing = False
+
+        root.title("File Converter")
+        root.geometry("560x420")
+        root.minsize(480, 260)
+
+        # Scrollable job list
+        container = ttk.Frame(root)
+        container.pack(fill="both", expand=True)
+        self.canvas = tk.Canvas(container, highlightthickness=0)
+        scrollbar = ttk.Scrollbar(container, orient="vertical",
+                                  command=self.canvas.yview)
+        self.list_frame = ttk.Frame(self.canvas)
+        self.list_frame.bind(
+            "<Configure>",
+            lambda e: self.canvas.configure(scrollregion=self.canvas.bbox("all")))
+        self._canvas_window = self.canvas.create_window(
+            (0, 0), window=self.list_frame, anchor="nw")
+        self.canvas.bind(
+            "<Configure>",
+            lambda e: self.canvas.itemconfigure(self._canvas_window, width=e.width))
+        self.canvas.configure(yscrollcommand=scrollbar.set)
+        self.canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
+        # Bottom bar with auto-close
+        ttk.Separator(root, orient="horizontal").pack(fill="x")
+        bottom = ttk.Frame(root, padding=(12, 8))
+        bottom.pack(fill="x")
+        bottom.columnconfigure(0, weight=1)
+        self.auto_close_label = ttk.Label(bottom, text="", anchor="w")
+        self.auto_close_label.grid(row=0, column=0, sticky="ew")
+        self.keep_open_btn = ttk.Button(bottom, text=_("Keep open"),
+                                        command=self._cancel_auto_close)
+        self.keep_open_btn.grid(row=0, column=1)
+        self.keep_open_btn.grid_remove()
+
+        for job in jobs:
+            row = JobRow(self.list_frame, job)
+            row.pack(fill="x")
+            self.job_rows.append(row)
+
+        root.protocol("WM_DELETE_WINDOW", self._on_close_request)
+        root.after(_POLL_MS, self._update_ui)
+
+    def start_conversions(self) -> None:
+        def _prepare_and_run(job: ConversionJob):
+            try:
+                job.prepare()
+                job.run()
+            except Exception as e:
+                job.state = ConversionState.FAILED
+                job.error_message = str(e)
+
+        def _worker():
+            with ThreadPoolExecutor(
+                    max_workers=self.settings.max_simultaneous_conversions) as pool:
+                pool.map(_prepare_and_run, self.jobs)
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    # ── UI updates (main thread only) ──
+
+    def _update_ui(self):
+        for row in self.job_rows:
+            row.update_row()
+
+        all_done = all(j.state in (ConversionState.DONE, ConversionState.FAILED)
+                       for j in self.jobs)
+        if all_done and self._auto_close_job is None and not self._auto_closing:
+            self.auto_close_label.configure(text=self._summary_status())
+            if self.settings.exit_when_done:
+                self._start_auto_close()
+
+        self.root.after(_POLL_MS, self._update_ui)
+
+    def _summary_status(self) -> str:
+        failed = sum(1 for j in self.jobs if j.state == ConversionState.FAILED)
+        done = sum(1 for j in self.jobs if j.state == ConversionState.DONE)
+        total = len(self.jobs)
+        if failed:
+            return _("{done}/{total} completed, {failed} failed").format(
+                done=done, total=total, failed=failed)
+        return _("{done}/{total} completed").format(done=done, total=total)
+
+    def _start_auto_close(self):
+        self._auto_closing = True
+        self._auto_close_seconds = self.settings.exit_delay_seconds
+        self.keep_open_btn.grid()
+        self._update_close_label()
+        self._auto_close_job = self.root.after(1000, self._auto_close_tick)
+
+    def _auto_close_tick(self):
+        self._auto_close_seconds -= 1
+        if self._auto_close_seconds <= 0:
+            self.root.destroy()
+            return
+        self._update_close_label()
+        self._auto_close_job = self.root.after(1000, self._auto_close_tick)
+
+    def _update_close_label(self):
+        self.auto_close_label.configure(text=_("{status} — closing in {seconds}s").format(
+            status=self._summary_status(), seconds=self._auto_close_seconds))
+
+    def _cancel_auto_close(self):
+        if self._auto_close_job is not None:
+            self.root.after_cancel(self._auto_close_job)
+            self._auto_close_job = None
+        self._auto_closing = False
+        self.keep_open_btn.grid_remove()
+        self.auto_close_label.configure(text=self._summary_status())
+
+    def _on_close_request(self):
+        # Ask running jobs to stop (kills their ffmpeg/magick subprocesses),
+        # then close. A short grace period lets the workers see the flag.
+        for job in self.jobs:
+            if job.state in (ConversionState.READY, ConversionState.IN_PROGRESS,
+                             ConversionState.UNKNOWN):
+                job.request_cancel()
+        self.root.after(250, self.root.destroy)
+
+
+def run_with_progress(jobs: list, settings: Settings) -> None:
+    """Launch the tkinter progress window and run conversions."""
+    root = tk.Tk()
+
+    # Finder-launched processes open behind other windows; nudge to front.
+    if sys.platform == "darwin":
+        try:
+            root.lift()
+            root.attributes("-topmost", True)
+            root.after(700, lambda: root.attributes("-topmost", False))
+        except tk.TclError:
+            pass
+
+    win = ProgressWindow(root, jobs, settings)
+    win.start_conversions()
+    root.mainloop()

--- a/fileconverter/ui/settings_window.py
+++ b/fileconverter/ui/settings_window.py
@@ -234,8 +234,9 @@ class SettingsWindow(Gtk.ApplicationWindow):
         self.exit_check.connect("toggled", self._on_exit_toggled)
         global_box.append(self.exit_check)
 
-        # Hardware acceleration
-        hw_labels = [_("Off"), _("Auto-detect"), _("NVENC (NVIDIA)"), _("VAAPI (AMD/Intel)")]
+        # Hardware acceleration (labels index-aligned with HWACCEL_MODES)
+        from fileconverter.config import HWACCEL_LABELS
+        hw_labels = [_(label) for label in HWACCEL_LABELS]
         self.hw_combo = Gtk.DropDown.new_from_strings(hw_labels)
         if settings.hardware_acceleration in HWACCEL_MODES:
             self.hw_combo.set_selected(HWACCEL_MODES.index(settings.hardware_acceleration))

--- a/fileconverter/ui/settings_window_tk.py
+++ b/fileconverter/ui/settings_window_tk.py
@@ -1,0 +1,425 @@
+"""tkinter settings window — feature-parity port of settings_window.py (GTK).
+
+Same layout: global settings + preset list on the left, per-preset editor on
+the right. On macOS, saving also regenerates the Finder Quick Actions so the
+context menu never drifts out of sync with the presets (GH #7).
+"""
+
+from __future__ import annotations
+import sys
+import tkinter as tk
+from tkinter import ttk
+
+from fileconverter.config import (
+    HWACCEL_LABELS, HWACCEL_MODES, Settings, load_settings, save_settings,
+)
+from fileconverter.helpers import ALL_INPUT_EXTENSIONS, OUTPUT_TYPES, VIDEO_CODECS
+from fileconverter import i18n
+from fileconverter.i18n import _
+from fileconverter.presets import ConversionPreset
+
+_SPEEDS = ["ultrafast", "superfast", "veryfast", "faster", "fast",
+           "medium", "slow", "slower", "veryslow"]
+_POST_ACTIONS = ["none", "archive", "delete"]
+
+
+class PresetEditor(ttk.Frame):
+    """Editor panel for a single preset."""
+
+    def __init__(self, parent, preset: ConversionPreset, on_change):
+        super().__init__(parent, padding=12)
+        self.preset = preset
+        self._on_change = on_change
+        self.columnconfigure(1, weight=1)
+        row = 0
+
+        # Name
+        ttk.Label(self, text=_("Name:")).grid(row=row, column=0, sticky="w")
+        self.name_var = tk.StringVar(value=preset.name)
+        self.name_var.trace_add("write", self._on_name_changed)
+        ttk.Entry(self, textvariable=self.name_var).grid(
+            row=row, column=1, sticky="ew", pady=2)
+        row += 1
+
+        # Output type
+        ttk.Label(self, text=_("Output:")).grid(row=row, column=0, sticky="w")
+        self.output_var = tk.StringVar(
+            value=preset.output_type if preset.output_type in OUTPUT_TYPES else "mp4")
+        out_menu = ttk.Combobox(self, textvariable=self.output_var,
+                                values=OUTPUT_TYPES, state="readonly", width=10)
+        out_menu.grid(row=row, column=1, sticky="w", pady=2)
+        out_menu.bind("<<ComboboxSelected>>", self._on_output_changed)
+        row += 1
+
+        # Input types (checkbox grid)
+        ttk.Label(self, text=_("Input types:")).grid(
+            row=row, column=0, columnspan=2, sticky="w", pady=(8, 2))
+        row += 1
+        grid = ttk.Frame(self)
+        grid.grid(row=row, column=0, columnspan=2, sticky="ew")
+        self._input_vars = {}
+        per_row = 8
+        for i, ext in enumerate(ALL_INPUT_EXTENSIONS):
+            var = tk.BooleanVar(value=ext in preset.input_types)
+            var.trace_add("write",
+                          lambda *a, e=ext, v=var: self._on_input_toggled(e, v))
+            self._input_vars[ext] = var
+            ttk.Checkbutton(grid, text=ext, variable=var).grid(
+                row=i // per_row, column=i % per_row, sticky="w", padx=2)
+        row += 1
+
+        # Conversion settings
+        ttk.Separator(self, orient="horizontal").grid(
+            row=row, column=0, columnspan=2, sticky="ew", pady=8)
+        row += 1
+        ttk.Label(self, text=_("Conversion settings:")).grid(
+            row=row, column=0, columnspan=2, sticky="w", pady=(0, 4))
+        row += 1
+
+        # (key, label, min, max, default) — mirrors the GTK editor exactly.
+        common_settings = [
+            ("video_codec", _("Video Codec"), None, None, None),
+            ("video_quality", _("Video Quality (0-63)"), 0, 63, 28),
+            ("video_encoding_speed", _("Encoding Speed"), None, None, None),
+            ("video_scale", _("Video Scale"), 0.1, 4.0, 1.0),
+            ("video_rotation", _("Rotation (degrees)"), 0, 270, 0),
+            ("audio_bitrate", _("Audio Bitrate"), 16, 500, 155),
+            ("image_quality", _("Image Quality (0-100)"), 0, 100, 85),
+            ("image_scale", _("Image Scale"), 0.1, 4.0, 1.0),
+            ("enable_audio", _("Enable Audio"), None, None, True),
+        ]
+
+        for key, label, min_val, max_val, default in common_settings:
+            ttk.Label(self, text=label).grid(row=row, column=0, sticky="w", pady=1)
+            current = preset.settings.get(key, default)
+
+            if isinstance(default, bool) or key == "enable_audio":
+                var = tk.BooleanVar(value=bool(current) if current is not None else True)
+                var.trace_add("write",
+                              lambda *a, k=key, v=var: self._set_setting(k, v.get()))
+                ttk.Checkbutton(self, variable=var).grid(row=row, column=1, sticky="w")
+            elif key == "video_encoding_speed":
+                var = tk.StringVar(value=str(current or "medium").lower())
+                combo = ttk.Combobox(self, textvariable=var, values=_SPEEDS,
+                                     state="readonly", width=12)
+                combo.grid(row=row, column=1, sticky="w", pady=1)
+                combo.bind("<<ComboboxSelected>>",
+                           lambda e, k=key, v=var: self._set_setting(k, v.get()))
+            elif key == "video_codec":
+                curr = str(current or "h264").lower()
+                if curr == "h265":
+                    curr = "hevc"
+                var = tk.StringVar(value=curr if curr in VIDEO_CODECS else "h264")
+                combo = ttk.Combobox(self, textvariable=var, values=VIDEO_CODECS,
+                                     state="readonly", width=12)
+                combo.grid(row=row, column=1, sticky="w", pady=1)
+                combo.bind("<<ComboboxSelected>>",
+                           lambda e, k=key, v=var: self._set_setting(k, v.get()))
+            else:
+                is_float = isinstance(default, float)
+                val = float(current) if current is not None else float(default)
+                var = tk.StringVar(value=f"{val:g}")
+                spin = ttk.Spinbox(
+                    self, textvariable=var, from_=float(min_val), to=float(max_val),
+                    increment=0.1 if is_float else 1, width=10,
+                    command=lambda k=key, v=var, f=is_float: self._on_spin(k, v, f))
+                spin.grid(row=row, column=1, sticky="w", pady=1)
+                var.trace_add("write",
+                              lambda *a, k=key, v=var, f=is_float: self._on_spin(k, v, f))
+            row += 1
+
+        # Post-conversion action
+        ttk.Label(self, text=_("After conversion:")).grid(
+            row=row, column=0, sticky="w", pady=(8, 1))
+        self.action_var = tk.StringVar(
+            value=preset.input_post_action
+            if preset.input_post_action in _POST_ACTIONS else "none")
+        action = ttk.Combobox(self, textvariable=self.action_var,
+                              values=_POST_ACTIONS, state="readonly", width=12)
+        action.grid(row=row, column=1, sticky="w", pady=(8, 1))
+        action.bind("<<ComboboxSelected>>", self._on_action_changed)
+        row += 1
+
+        # Output template
+        ttk.Label(self, text=_("Output template:")).grid(row=row, column=0, sticky="w")
+        self.tmpl_var = tk.StringVar(value=preset.output_template)
+        self.tmpl_var.trace_add("write", self._on_template_changed)
+        ttk.Entry(self, textvariable=self.tmpl_var).grid(
+            row=row, column=1, sticky="ew", pady=2)
+        row += 1
+        ttk.Label(
+            self, foreground="gray",
+            text=_("Variables: (p) path, (f) filename, (o) output ext, (i) input ext"),
+        ).grid(row=row, column=0, columnspan=2, sticky="w")
+
+    def _on_name_changed(self, *args):
+        self.preset.name = self.name_var.get()
+        self._on_change()
+
+    def _on_output_changed(self, _event=None):
+        self.preset.output_type = self.output_var.get()
+        self._on_change()
+
+    def _on_input_toggled(self, ext: str, var: tk.BooleanVar):
+        if var.get():
+            if ext not in self.preset.input_types:
+                self.preset.input_types.append(ext)
+        else:
+            if ext in self.preset.input_types:
+                self.preset.input_types.remove(ext)
+        self._on_change()
+
+    def _set_setting(self, key: str, value):
+        self.preset.settings[key] = value
+        self._on_change()
+
+    def _on_spin(self, key: str, var: tk.StringVar, is_float: bool):
+        try:
+            value = float(var.get())
+        except ValueError:
+            return  # mid-edit, e.g. empty field
+        self._set_setting(key, value if is_float else int(value))
+
+    def _on_action_changed(self, _event=None):
+        self.preset.input_post_action = self.action_var.get()
+        self._on_change()
+
+    def _on_template_changed(self, *args):
+        self.preset.output_template = self.tmpl_var.get()
+        self._on_change()
+
+
+class SettingsWindow:
+    def __init__(self, root: tk.Tk, settings: Settings):
+        self.root = root
+        self.settings = settings
+        self._modified = False
+        self._editor = None
+
+        root.title(_("File Converter — Settings"))
+        root.geometry("860x620")
+        root.minsize(720, 480)
+
+        paned = ttk.Panedwindow(root, orient="horizontal")
+        paned.pack(fill="both", expand=True)
+
+        # ── Left: global settings + preset list ──
+        left = ttk.Frame(paned, padding=8)
+        paned.add(left, weight=0)
+
+        glob = ttk.Labelframe(left, text=_("Global"), padding=8)
+        glob.pack(fill="x")
+        glob.columnconfigure(1, weight=1)
+
+        ttk.Label(glob, text=_("Max jobs:")).grid(row=0, column=0, sticky="w")
+        self.max_var = tk.StringVar(value=str(settings.max_simultaneous_conversions))
+        self.max_var.trace_add("write", self._on_max_changed)
+        ttk.Spinbox(glob, textvariable=self.max_var, from_=1, to=16, width=6).grid(
+            row=0, column=1, sticky="w", pady=2)
+
+        self.exit_var = tk.BooleanVar(value=settings.exit_when_done)
+        self.exit_var.trace_add("write", self._on_exit_toggled)
+        ttk.Checkbutton(glob, text=_("Auto-close when done"),
+                        variable=self.exit_var).grid(
+            row=1, column=0, columnspan=2, sticky="w", pady=2)
+
+        ttk.Label(glob, text=_("GPU accel:")).grid(row=2, column=0, sticky="w")
+        hw_labels = [_(label) for label in HWACCEL_LABELS]
+        current_hw = (settings.hardware_acceleration
+                      if settings.hardware_acceleration in HWACCEL_MODES else "off")
+        self.hw_var = tk.StringVar(value=hw_labels[HWACCEL_MODES.index(current_hw)])
+        hw_combo = ttk.Combobox(glob, textvariable=self.hw_var, values=hw_labels,
+                                state="readonly", width=20)
+        hw_combo.grid(row=2, column=1, sticky="w", pady=2)
+        hw_combo.bind("<<ComboboxSelected>>",
+                      lambda e: self._on_hw_changed(hw_labels))
+
+        ttk.Label(glob, text=_("Language:")).grid(row=3, column=0, sticky="w")
+        detected = i18n.detect_system_language() or ""
+        detected_label = dict(i18n.SUPPORTED_LANGUAGES).get(detected)
+        auto_label = (_("System default ({name})").format(name=detected_label)
+                      if detected_label else _("System default"))
+        self._lang_labels = [auto_label] + [
+            label for code, label in i18n.SUPPORTED_LANGUAGES if code != "auto"]
+        current_lang = (settings.language
+                        if settings.language in i18n.LANGUAGE_CODES else "auto")
+        self.lang_var = tk.StringVar(
+            value=self._lang_labels[i18n.LANGUAGE_CODES.index(current_lang)])
+        lang_combo = ttk.Combobox(glob, textvariable=self.lang_var,
+                                  values=self._lang_labels, state="readonly", width=20)
+        lang_combo.grid(row=3, column=1, sticky="w", pady=2)
+        lang_combo.bind("<<ComboboxSelected>>", self._on_lang_changed)
+
+        ttk.Label(left, text=_("Presets")).pack(anchor="w", pady=(8, 2))
+        list_frame = ttk.Frame(left)
+        list_frame.pack(fill="both", expand=True)
+        self.preset_list = tk.Listbox(list_frame, exportselection=False)
+        list_scroll = ttk.Scrollbar(list_frame, orient="vertical",
+                                    command=self.preset_list.yview)
+        self.preset_list.configure(yscrollcommand=list_scroll.set)
+        self.preset_list.pack(side="left", fill="both", expand=True)
+        list_scroll.pack(side="right", fill="y")
+        self.preset_list.bind("<<ListboxSelect>>", self._on_preset_selected)
+
+        btns = ttk.Frame(left)
+        btns.pack(fill="x", pady=(4, 0))
+        ttk.Button(btns, text=_("Add"), command=self._on_add_preset).pack(
+            side="left", padx=(0, 4))
+        ttk.Button(btns, text=_("Remove"), command=self._on_remove_preset).pack(
+            side="left")
+        ttk.Button(btns, text=_("Save"), command=self._on_save).pack(side="right")
+
+        # ── Right: scrollable editor ──
+        right = ttk.Frame(paned)
+        paned.add(right, weight=1)
+        self.editor_canvas = tk.Canvas(right, highlightthickness=0)
+        editor_scroll = ttk.Scrollbar(right, orient="vertical",
+                                      command=self.editor_canvas.yview)
+        self.editor_canvas.configure(yscrollcommand=editor_scroll.set)
+        self.editor_canvas.pack(side="left", fill="both", expand=True)
+        editor_scroll.pack(side="right", fill="y")
+        self._canvas_item = None
+        self.editor_canvas.bind(
+            "<Configure>",
+            lambda e: self._canvas_item and self.editor_canvas.itemconfigure(
+                self._canvas_item, width=e.width))
+
+        self._placeholder()
+        self._refresh_preset_list()
+
+    # ── Left panel handlers ──
+
+    def _refresh_preset_list(self):
+        self.preset_list.delete(0, "end")
+        for preset in self.settings.presets:
+            self.preset_list.insert("end", preset.name)
+
+    def _selected_index(self):
+        sel = self.preset_list.curselection()
+        return sel[0] if sel else None
+
+    def _placeholder(self):
+        self._set_editor(ttk.Label(self.editor_canvas,
+                                   text=_("Select a preset to edit"), padding=20))
+
+    def _set_editor(self, widget):
+        if self._canvas_item is not None:
+            self.editor_canvas.delete(self._canvas_item)
+        self._editor = widget
+        self._canvas_item = self.editor_canvas.create_window(
+            (0, 0), window=widget, anchor="nw",
+            width=max(self.editor_canvas.winfo_width(), 400))
+        widget.bind(
+            "<Configure>",
+            lambda e: self.editor_canvas.configure(
+                scrollregion=self.editor_canvas.bbox("all")))
+
+    def _on_preset_selected(self, _event=None):
+        idx = self._selected_index()
+        if idx is None or not (0 <= idx < len(self.settings.presets)):
+            return
+        self._set_editor(PresetEditor(self.editor_canvas,
+                                      self.settings.presets[idx],
+                                      self._mark_modified))
+
+    def _on_add_preset(self):
+        new_preset = ConversionPreset(
+            name=_("New Preset"),
+            output_type="mp4",
+            input_types=["avi", "mkv", "mov", "mp4", "webm"],
+            settings={"enable_audio": True, "video_quality": 28,
+                      "video_encoding_speed": "medium",
+                      "audio_bitrate": 155, "video_scale": 1.0},
+        )
+        self.settings.presets.append(new_preset)
+        self._refresh_preset_list()
+        self.preset_list.selection_clear(0, "end")
+        self.preset_list.selection_set("end")
+        self.preset_list.see("end")
+        self._on_preset_selected()
+        self._mark_modified()
+
+    def _on_remove_preset(self):
+        idx = self._selected_index()
+        if idx is not None and 0 <= idx < len(self.settings.presets):
+            self.settings.presets.pop(idx)
+            self._refresh_preset_list()
+            self._placeholder()
+            self._mark_modified()
+
+    def _on_max_changed(self, *args):
+        try:
+            self.settings.max_simultaneous_conversions = max(
+                1, min(16, int(self.max_var.get())))
+            self._mark_modified()
+        except ValueError:
+            pass
+
+    def _on_exit_toggled(self, *args):
+        self.settings.exit_when_done = self.exit_var.get()
+        self._mark_modified()
+
+    def _on_hw_changed(self, hw_labels):
+        try:
+            idx = hw_labels.index(self.hw_var.get())
+        except ValueError:
+            return
+        self.settings.hardware_acceleration = HWACCEL_MODES[idx]
+        self._mark_modified()
+
+    def _on_lang_changed(self, _event=None):
+        try:
+            idx = self._lang_labels.index(self.lang_var.get())
+        except ValueError:
+            return
+        code = i18n.LANGUAGE_CODES[idx]
+        if code == self.settings.language:
+            return
+        self.settings.language = code
+        save_settings(self.settings)
+        self._modified = False
+        i18n.init(code)
+        # Rebuild the window so every label picks up the new language.
+        for child in self.root.winfo_children():
+            child.destroy()
+        SettingsWindow(self.root, self.settings)
+
+    def _on_save(self):
+        save_settings(self.settings)
+        self._modified = False
+        if sys.platform == "darwin":
+            # Keep the Finder context menu in sync with the presets (GH #7).
+            try:
+                from fileconverter.integration.macos import refresh_services
+                refresh_services(quiet=True)
+            except Exception:
+                pass
+        self.root.title(_("File Converter — Settings (saved)"))
+        self.root.after(2000,
+                        lambda: self.root.title(_("File Converter — Settings")))
+        self._refresh_preset_list()
+
+    def _mark_modified(self):
+        self._modified = True
+        self.root.title(_("File Converter — Settings *"))
+
+
+def run_settings() -> None:
+    root = tk.Tk()
+    settings = load_settings()
+    i18n.init(settings.language)
+
+    if sys.platform == "darwin":
+        try:
+            root.lift()
+            root.attributes("-topmost", True)
+            root.after(700, lambda: root.attributes("-topmost", False))
+        except tk.TclError:
+            pass
+
+    SettingsWindow(root, settings)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    run_settings()

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# File Converter for macOS — installer
+#
+# Installs the tool into ~/.local/share/fileconverter (payload + private
+# venv), then hands off to `fileconverter --install`, which checks the
+# media tools, writes the launchers and generates the Finder Quick Actions.
+#
+# A private venv from source — rather than a prebuilt binary — is deliberate:
+# the Linux prebuilt binary broke against rolling-release system libraries
+# (GH #6) and tripped "not authorized to execute" policies (GH #5).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_DIR="$HOME/.local/share/fileconverter"
+PAYLOAD="$APP_DIR/app"
+VENV="$APP_DIR/venv"
+
+echo ""
+echo "=== File Converter for macOS — Install ==="
+echo ""
+
+# ── 1. Pick a Python ──
+# The main UI is native SwiftUI (compiled during setup); tkinter is only the
+# fallback. Still, prefer the interpreter with the NEWEST Tk: Apple's bundled
+# Tk 8.5 draws blank windows on recent macOS, while Homebrew's python-tk
+# ships a current Tk.
+PYTHON=""
+BEST_TK="0"
+CANDIDATES=("/usr/bin/python3")
+if command -v brew >/dev/null 2>&1; then
+    BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+    [ -n "$BREW_PREFIX" ] && CANDIDATES+=("$BREW_PREFIX/bin/python3")
+fi
+if OTHER="$(command -v python3 2>/dev/null)"; then
+    CANDIDATES+=("$OTHER")
+fi
+
+for cand in "${CANDIDATES[@]}"; do
+    [ -n "$cand" ] && [ -x "$cand" ] || continue
+    "$cand" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)' 2>/dev/null || continue
+    TK_VER="$("$cand" -c 'import tkinter; print(tkinter.TkVersion)' 2>/dev/null || echo 0)"
+    if [ -z "$PYTHON" ] || [ "$(printf '%s\n%s\n' "$BEST_TK" "$TK_VER" | sort -g | tail -1)" = "$TK_VER" ] \
+       && [ "$TK_VER" != "$BEST_TK" ]; then
+        PYTHON="$cand"
+        BEST_TK="$TK_VER"
+    fi
+done
+
+if [ -z "$PYTHON" ]; then
+    echo "Python 3.9+ not found. Install the Xcode Command Line Tools first:"
+    echo "  xcode-select --install"
+    exit 1
+fi
+if [ "$BEST_TK" = "0" ]; then
+    echo "note: no tkinter found — GUI falls back to the native SwiftUI front-end"
+    echo "      only (built during setup if the Command Line Tools are present)."
+fi
+echo "Using Python: $PYTHON ($("$PYTHON" -c 'import platform; print(platform.python_version())'), Tk $BEST_TK)"
+
+# ── 2. Copy the payload ──
+mkdir -p "$PAYLOAD"
+rsync -a --delete \
+    "$SCRIPT_DIR/fileconverter" \
+    "$SCRIPT_DIR/resources" \
+    "$SCRIPT_DIR/locales" \
+    "$PAYLOAD/"
+
+# ── 3. Private venv with PyYAML (rebuilt if the chosen Python changed) ──
+MARKER="$APP_DIR/.venv-python"
+if [ -x "$VENV/bin/python3" ]; then
+    RECORDED="$( [ -f "$MARKER" ] && cat "$MARKER" || echo "unknown" )"
+    if [ "$RECORDED" != "$PYTHON" ]; then
+        echo "Python changed ($RECORDED → $PYTHON) — rebuilding venv..."
+        rm -rf "$VENV"
+    fi
+fi
+if [ ! -x "$VENV/bin/python3" ]; then
+    echo "Creating venv..."
+    "$PYTHON" -m venv "$VENV"
+fi
+printf '%s' "$PYTHON" > "$MARKER"
+"$VENV/bin/python3" -m pip install --quiet --disable-pip-version-check pyyaml
+
+# ── 4. Hand off to the Python installer (deps, launchers, Quick Actions) ──
+cd "$PAYLOAD"
+exec "$VENV/bin/python3" -m fileconverter --install

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# File Converter for Linux — installer
-# Works on any distro: Ubuntu, Fedora, Arch, openSUSE, etc.
-# Can be run from source or will use PyInstaller binary if built.
+# File Converter — installer
+# Linux: works on any distro (Ubuntu, Fedora, Arch, openSUSE, ...).
+# macOS: dispatches to install-macos.sh (Finder Quick Actions).
+# Can be run from source or will use PyInstaller binary if built (Linux only).
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# macOS gets its own installer (venv + Finder Quick Actions)
+if [ "$(uname -s)" = "Darwin" ]; then
+    exec bash "$SCRIPT_DIR/install-macos.sh" "$@"
+fi
 
 # Check if there's a built binary
 if [ -f "$SCRIPT_DIR/dist/fileconverter" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fileconverter"
-version = "1.3.0"
-description = "Linux port of File Converter — right-click context menu file conversion"
+version = "1.4.0"
+description = "Linux and macOS port of File Converter — right-click context menu file conversion"
 license = "GPL-3.0-or-later"
-requires-python = ">=3.10"
+# 3.9 floor so the macOS system Python (Command Line Tools) works out of the box.
+requires-python = ">=3.9"
 dependencies = [
     "PyYAML>=6.0",
-    "PyGObject>=3.42",
+    # GTK bindings are only used (and only installable sanely) on Linux;
+    # macOS uses tkinter from the standard library.
+    'PyGObject>=3.42; sys_platform == "linux"',
 ]
 
 [project.scripts]

--- a/tests/fcutil.py
+++ b/tests/fcutil.py
@@ -147,14 +147,41 @@ def _identify(args):
                           capture_output=True, text=True)
 
 
+# ffprobe codec_name → ImageMagick format code, for builds whose identify
+# lacks a *read* delegate for a format the converter can still produce
+# (e.g. Homebrew ImageMagick has no OpenJPEG, so JP2 goes via ffmpeg).
+_FFPROBE_FORMAT_CODES = {
+    "jpeg2000": "JP2", "png": "PNG", "mjpeg": "JPEG", "webp": "WEBP",
+    "tiff": "TIFF", "bmp": "BMP", "targa": "TGA", "gif": "GIF",
+}
+
+
 def image_format(path):
     """Return the ImageMagick format code of the first frame, e.g. 'JP2'."""
     out = _identify(["-format", "%m\n", str(path)])
-    return out.stdout.strip().splitlines()[0] if out.stdout.strip() else ""
+    if out.stdout.strip():
+        return out.stdout.strip().splitlines()[0]
+    if HAS_FFPROBE:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=codec_name", "-of", "csv=p=0", str(path)],
+            capture_output=True, text=True)
+        codec = probe.stdout.strip().splitlines()[0] if probe.stdout.strip() else ""
+        return _FFPROBE_FORMAT_CODES.get(codec, codec.upper())
+    return ""
 
 
 def image_dims(path):
     out = _identify(["-format", "%w %h\n", str(path)])
-    first = out.stdout.strip().splitlines()[0]
-    w, h = first.split()
-    return int(w), int(h)
+    if out.stdout.strip():
+        w, h = out.stdout.strip().splitlines()[0].split()
+        return int(w), int(h)
+    if HAS_FFPROBE:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=width,height", "-of", "csv=p=0", str(path)],
+            capture_output=True, text=True)
+        if probe.stdout.strip():
+            w, h = probe.stdout.strip().splitlines()[0].split(",")
+            return int(w), int(h)
+    raise AssertionError(f"could not determine image dimensions of {path}")


### PR DESCRIPTION
Full macOS support, kept 1:1 with the Linux version: same conversion engine, same 46 presets, same CLI (`fileconverter --conversion-preset 'To Mp4' file.avi`), same YAML config and 29-language i18n.

## Finder integration

A **Finder Sync extension** (built into `File Converter.app` by the installer) adds a real right-click submenu, matching the Linux file-manager UX:

```
Right-click video.mkv >
  File Converter
  ├── To Mp4
  ├── To Gif
  ├── To Mp3
  ├── ...
  └── Configure presets...
```

- Filtering is per-extension in the extension itself (the #7 class of bug — every preset offered on every file — is structurally impossible here), and the menu re-reads `menu.json` on every click so settings changes apply instantly.
- Without the Xcode CLT, the installer falls back to one **UTI-scoped Quick Action per preset**, including LaunchServices-resolved dynamic UTIs so `.mkv` & co. (which macOS doesn't claim natively) still show the right entries.
- Menu clicks go through a `fileconverter://` URL handled by the host app, which stays alive for the whole conversion so TCC folder prompts (Downloads, Desktop…) are asked in the name of "File Converter", not `python3.x`.

## Native UI

Progress window, preset picker and full settings editor are **native SwiftUI**, compiled on the spot by the installer. The Swift binary is a dumb renderer driven by Python over a JSON-lines protocol — conversions, ETA math, auto-close and translations all stay in Python. A feature-parity **tkinter** fallback covers systems without the CLT, and doubles as the **GTK fallback on Linux** (relevant to the #5 crash class; note Apple's bundled Tk 8.5 draws blank windows on recent macOS — Homebrew's `python-tk` works).

## Engine

- **VideoToolbox** hw accel (auto-detected, with software retry) joins NVENC/VAAPI; HEVC keeps the `hvc1` tag.
- **Encoder-aware builders**: Homebrew ffmpeg 8 ships no libvorbis/libtheora — WebM audio falls back to Opus (spec-valid), OGV fails with an actionable message instead of `Error selecting an encoder`.
- **ImageMagick hardening**: Homebrew IM lacks the OpenJPEG delegate and silently writes wrong-format bytes with exit 0 — outputs are now format-validated, and JP2 routes through ffmpeg's native JPEG-2000 encoder (PDF pages chained). Benefits Linux too.
- ICO capped at 256px (was a hard ffmpeg error), animated GIF → still formats takes frame 1 instead of scattering `out-0.png…`.

## Install / uninstall

`./install.sh` on macOS → source install into a private venv under `~/.local/share/fileconverter` (no PyInstaller onefile — the #6 breakage class), Homebrew dependency detection with optional auto-install, launchers in `~/.local/bin`. `fileconverter --uninstall` removes everything.

## Testing

- **161/161 tests** pass on macOS under Python 3.9 and 3.14 (suite gained ffprobe fallbacks where Homebrew IM can't read a format it didn't write).
- 47/48 presets exercised end-to-end on real files (video/audio/image/PDF/office); the 1 exception is OGV's clean unavailable-encoder message.
- Quick Actions executed via `automator` exactly as Finder runs them, including multi-select batches; URL→host→conversion path verified.
- Linux behaviour unchanged (GTK path untouched; backends only gained fallbacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)